### PR TITLE
Fix dev JWT secret fallback not reaching AuthService

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Services/AuthServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/AuthServiceTests.cs
@@ -280,6 +280,54 @@ public class AuthServiceTests : IDisposable
             .WithMessage("*JWT Secret*");
     }
 
+    [Fact]
+    public async Task GenerateJwtToken_WithEmptySecret_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        // appsettings.json ships "Secret": "" - an empty string must be treated as
+        // missing, not passed to SymmetricSecurityKey (which throws ArgumentException)
+        var mockConfigEmptySecret = new Mock<IConfiguration>();
+        mockConfigEmptySecret.Setup(c => c["Jwt:Secret"]).Returns("");
+        var serviceEmptySecret = new AuthService(_context, mockConfigEmptySecret.Object, _mockNotificationService.Object);
+        var request = new RegisterRequest("emptysecret@example.com", "Password1!", "John", "Doe", null, null, null);
+
+        // Act
+        var act = () => serviceEmptySecret.RegisterAsync(request);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*JWT Secret*");
+    }
+
+    [Fact]
+    public async Task GenerateJwtToken_WithDevFallbackWrittenToConfiguration_ReturnsToken()
+    {
+        // Arrange
+        // Mirrors Program.cs: config ships an empty secret, then the development
+        // fallback is written back so all readers of Jwt:Secret see it
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Secret"] = "",
+                ["Jwt:Issuer"] = "test-issuer",
+                ["Jwt:Audience"] = "test-audience",
+                ["Jwt:ExpiryMinutes"] = "60"
+            })
+            .Build();
+        configuration["Jwt:Secret"] = "dev-secret-key-for-local-development-only-min-32-chars";
+        var serviceWithFallback = new AuthService(_context, configuration, _mockNotificationService.Object);
+        var request = new RegisterRequest("devfallback@example.com", "Password1!", "John", "Doe", null, null, null);
+
+        // Act
+        var result = await serviceWithFallback.RegisterAsync(request);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Token.Should().NotBeNullOrEmpty();
+        var token = new JwtSecurityTokenHandler().ReadJwtToken(result.Token);
+        token.Issuer.Should().Be("test-issuer");
+    }
+
     #endregion
 
     #region Logout Tests

--- a/apps/api/BHMHockey.Api/Program.cs
+++ b/apps/api/BHMHockey.Api/Program.cs
@@ -85,6 +85,9 @@ if (string.IsNullOrEmpty(jwtSecret))
     if (builder.Environment.IsDevelopment())
     {
         jwtSecret = "dev-secret-key-for-local-development-only-min-32-chars";
+        // Write the fallback back into configuration so services reading Jwt:Secret
+        // (e.g. AuthService token generation) use the same key as token validation
+        builder.Configuration["Jwt:Secret"] = jwtSecret;
         Console.WriteLine("⚠️  WARNING: Using development JWT secret. Set Jwt:Secret in .env for production!");
     }
     else

--- a/apps/api/BHMHockey.Api/Services/AuthService.cs
+++ b/apps/api/BHMHockey.Api/Services/AuthService.cs
@@ -282,8 +282,12 @@ public class AuthService : IAuthService
 
     private string GenerateJwtToken(User user)
     {
-        var jwtSecret = _configuration["Jwt:Secret"]
-            ?? throw new InvalidOperationException("JWT Secret not configured");
+        var jwtSecret = _configuration["Jwt:Secret"];
+        if (string.IsNullOrWhiteSpace(jwtSecret))
+        {
+            // Empty string counts as missing - a zero-length key would fail signing
+            throw new InvalidOperationException("JWT Secret not configured");
+        }
         var issuer = _configuration["Jwt:Issuer"];
         var audience = _configuration["Jwt:Audience"];
         var expiryMinutes = int.Parse(_configuration["Jwt:ExpiryMinutes"] ?? "60");


### PR DESCRIPTION
## Bug

On a fresh clone in Development with no `Jwt__Secret` env var, `POST /api/auth/register` and `POST /api/auth/login` return HTTP 500 (`System.ArgumentException: IDX10703 ... key length is zero`). This contradicts the README's promise that the JWT secret is auto-defaulted in development. Introduced by 1868482 ("Harden JWT config and untrack local Claude settings").

## Root cause

`Program.cs` computes the dev fallback secret into a local variable used only by the `AddJwtBearer` token-validation setup — it is never written back into configuration. `AuthService.GenerateJwtToken` reads `_configuration["Jwt:Secret"]` directly with a `?? throw` guard, but `appsettings.json` ships `"Secret": ""` — an empty string, not null — so the guard never fires and the zero-length key reaches `SymmetricSecurityKey`, which throws.

## Fix

- **Program.cs**: after computing the dev fallback, write it back with `builder.Configuration["Jwt:Secret"] = jwtSecret;` so all config readers (including AuthService) see the same key. Non-Development still throws when the secret is missing; the console warning is kept.
- **AuthService.GenerateJwtToken**: harden the guard with `string.IsNullOrWhiteSpace` so an empty/whitespace secret throws `InvalidOperationException` instead of ever reaching `SymmetricSecurityKey` (defense in depth).

## Tests added (AuthServiceTests)

- `GenerateJwtToken_WithEmptySecret_ThrowsInvalidOperationException` — empty-string secret now throws `InvalidOperationException` (previously `ArgumentException` from a zero-length key).
- `GenerateJwtToken_WithDevFallbackWrittenToConfiguration_ReturnsToken` — mirrors the Program.cs flow: config ships an empty secret, the fallback is written back via the configuration indexer, and token generation succeeds.

Full API suite: 896 passed, 0 failed. `yarn test` (API + shared + api-client + mobile): all green (896 / 37 / 22 / 77).

## End-to-end verification

With `Jwt__Secret` unset and the checked-in empty `appsettings.json` secret, ran the API in Development on a side port (the dev `UseUrls` hardcodes 5001, which was occupied, so the verification instance was an identical copy differing only in the listen URL):

- `POST /api/auth/register` → 200 with token (500 before the fix)
- `POST /api/auth/login` → 200 with token
- Authenticated `GET /api/users/me` with the issued token → 200, proving token generation and validation now share the same fallback key
- Startup log shows the expected dev-secret warning

Test user was deleted from the local DB afterward.

## Scope notes

- No DTO / `packages/shared` type changes needed — no data shapes changed (considered per the backend-change checklist).
- No migrations needed — no entity changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)