### PR TITLE
Add organization auto-roster: regulars automatically placed on event rosters

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
@@ -4,6 +4,7 @@ using BHMHockey.Api.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using System.Security.Claims;
 using Xunit;
@@ -18,6 +19,7 @@ public class OrganizationsControllerTests
 {
     private readonly Mock<IOrganizationService> _mockOrgService;
     private readonly Mock<IOrganizationAdminService> _mockAdminService;
+    private readonly Mock<IOrganizationAutoRosterService> _mockAutoRosterService;
     private readonly OrganizationsController _controller;
     private readonly Guid _testUserId = Guid.NewGuid();
 
@@ -25,7 +27,12 @@ public class OrganizationsControllerTests
     {
         _mockOrgService = new Mock<IOrganizationService>();
         _mockAdminService = new Mock<IOrganizationAdminService>();
-        _controller = new OrganizationsController(_mockOrgService.Object, _mockAdminService.Object);
+        _mockAutoRosterService = new Mock<IOrganizationAutoRosterService>();
+        _controller = new OrganizationsController(
+            _mockOrgService.Object,
+            _mockAdminService.Object,
+            _mockAutoRosterService.Object,
+            Mock.Of<ILogger<OrganizationsController>>());
     }
 
     #region GetAll Tests
@@ -269,6 +276,170 @@ public class OrganizationsControllerTests
 
     #endregion
 
+    #region Auto-Roster Tests
+
+    [Fact]
+    public async Task GetAutoRoster_AsAdmin_ReturnsMembers()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var members = new List<AutoRosterMemberDto> { CreateAutoRosterMemberDto(sortOrder: 0) };
+        _mockAutoRosterService.Setup(s => s.GetAutoRosterAsync(orgId, _testUserId)).ReturnsAsync(members);
+
+        // Act
+        var result = await _controller.GetAutoRoster(orgId);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        (okResult!.Value as List<AutoRosterMemberDto>).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetAutoRoster_AsNonAdmin_ReturnsForbidden()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        _mockAutoRosterService.Setup(s => s.GetAutoRosterAsync(orgId, _testUserId))
+            .ThrowsAsync(new UnauthorizedAccessException("Not an admin"));
+
+        // Act
+        var result = await _controller.GetAutoRoster(orgId);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task AddAutoRosterMember_WithValidRequest_ReturnsMember()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+        var request = new AddAutoRosterMemberRequest(memberUserId, "Skater");
+        var member = CreateAutoRosterMemberDto(userId: memberUserId);
+        _mockAutoRosterService.Setup(s => s.AddMemberAsync(orgId, memberUserId, "Skater", _testUserId))
+            .ReturnsAsync(member);
+
+        // Act
+        var result = await _controller.AddAutoRosterMember(orgId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+        var okResult = result.Result as OkObjectResult;
+        (okResult!.Value as AutoRosterMemberDto)!.UserId.Should().Be(memberUserId);
+    }
+
+    [Fact]
+    public async Task AddAutoRosterMember_WhenNotSubscriber_Returns400()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var request = new AddAutoRosterMemberRequest(Guid.NewGuid(), "Skater");
+        _mockAutoRosterService.Setup(s => s.AddMemberAsync(orgId, request.UserId, "Skater", _testUserId))
+            .ThrowsAsync(new InvalidOperationException("User must be a member of this organization"));
+
+        // Act
+        var result = await _controller.AddAutoRosterMember(orgId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task AddAutoRosterMember_AsNonAdmin_ReturnsForbidden()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var request = new AddAutoRosterMemberRequest(Guid.NewGuid(), "Skater");
+        _mockAutoRosterService.Setup(s => s.AddMemberAsync(orgId, request.UserId, "Skater", _testUserId))
+            .ThrowsAsync(new UnauthorizedAccessException("Not an admin"));
+
+        // Act
+        var result = await _controller.AddAutoRosterMember(orgId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task RemoveAutoRosterMember_WhenInList_Returns204()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+        _mockAutoRosterService.Setup(s => s.RemoveMemberAsync(orgId, memberUserId, _testUserId)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.RemoveAutoRosterMember(orgId, memberUserId);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task RemoveAutoRosterMember_WhenNotInList_Returns404()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var memberUserId = Guid.NewGuid();
+        _mockAutoRosterService.Setup(s => s.RemoveMemberAsync(orgId, memberUserId, _testUserId)).ReturnsAsync(false);
+
+        // Act
+        var result = await _controller.RemoveAutoRosterMember(orgId, memberUserId);
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task ReorderAutoRoster_WithValidOrder_ReturnsMembers()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var orderedIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var request = new ReorderAutoRosterRequest(orderedIds);
+        var members = new List<AutoRosterMemberDto>
+        {
+            CreateAutoRosterMemberDto(userId: orderedIds[0], sortOrder: 0),
+            CreateAutoRosterMemberDto(userId: orderedIds[1], sortOrder: 1)
+        };
+        _mockAutoRosterService.Setup(s => s.ReorderAsync(orgId, orderedIds, _testUserId)).ReturnsAsync(members);
+
+        // Act
+        var result = await _controller.ReorderAutoRoster(orgId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<OkObjectResult>();
+    }
+
+    [Fact]
+    public async Task ReorderAutoRoster_WithIncompleteList_Returns400()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var request = new ReorderAutoRosterRequest(new List<Guid> { Guid.NewGuid() });
+        _mockAutoRosterService.Setup(s => s.ReorderAsync(orgId, request.OrderedUserIds, _testUserId))
+            .ThrowsAsync(new InvalidOperationException("All auto-roster members must be included exactly once"));
+
+        // Act
+        var result = await _controller.ReorderAutoRoster(orgId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private void SetupAuthenticatedUser(Guid userId, string role = "Organizer")
@@ -285,6 +456,20 @@ public class OrganizationsControllerTests
         {
             HttpContext = new DefaultHttpContext { User = principal }
         };
+    }
+
+    private AutoRosterMemberDto CreateAutoRosterMemberDto(Guid? userId = null, int sortOrder = 0)
+    {
+        return new AutoRosterMemberDto(
+            Guid.NewGuid(),
+            userId ?? Guid.NewGuid(),
+            "Test",
+            "User",
+            new Dictionary<string, string> { { "skater", "Silver" } },
+            "Skater",
+            sortOrder,
+            DateTime.UtcNow
+        );
     }
 
     private OrganizationDto CreateOrgDto(string name, bool isSubscribed = false, bool isCreator = false)

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -173,6 +173,265 @@ public class EventServiceTests : IDisposable
         return registration;
     }
 
+    private async Task<OrganizationAutoRosterMember> AddAutoRosterMember(
+        Guid orgId,
+        Guid userId,
+        string position,
+        int sortOrder,
+        Guid? addedByUserId = null)
+    {
+        var member = new OrganizationAutoRosterMember
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = orgId,
+            UserId = userId,
+            Position = position,
+            SortOrder = sortOrder,
+            AddedAt = DateTime.UtcNow,
+            AddedByUserId = addedByUserId
+        };
+
+        _context.OrganizationAutoRosterMembers.Add(member);
+        await _context.SaveChangesAsync();
+        return member;
+    }
+
+    private CreateEventRequest CreateEventRequestFor(
+        Guid orgId,
+        int maxPlayers = 10,
+        decimal cost = 0,
+        bool applyAutoRoster = true)
+    {
+        return new CreateEventRequest(
+            EventDate: DateTime.UtcNow.AddDays(7),
+            MaxPlayers: maxPlayers,
+            Cost: cost,
+            OrganizationId: orgId,
+            Name: "Auto Roster Test Event",
+            ApplyAutoRoster: applyAutoRoster);
+    }
+
+    #endregion
+
+    #region Auto-Roster Application Tests
+
+    [Fact]
+    public async Task CreateAsync_WithAutoRoster_PaidEvent_RegistersMembersWithPendingPayment()
+    {
+        // Arrange
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("regular1@example.com");
+        var user2 = await CreateTestUser("regular2@example.com");
+        await CreateSubscription(org.Id, user1.Id);
+        await CreateSubscription(org.Id, user2.Id);
+        await AddAutoRosterMember(org.Id, user1.Id, "Skater", 0);
+        await AddAutoRosterMember(org.Id, user2.Id, "Skater", 1);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id, maxPlayers: 10, cost: 20m), admin.Id);
+
+        // Assert - paid events do NOT waitlist auto-roster members (organizer-add semantics)
+        var registrations = await _context.EventRegistrations
+            .Where(r => r.EventId == result.Id)
+            .ToListAsync();
+        registrations.Should().HaveCount(2);
+        registrations.Should().OnlyContain(r => r.Status == "Registered");
+        registrations.Should().OnlyContain(r => r.PaymentStatus == "Pending");
+        registrations.Should().OnlyContain(r => r.PaymentDeadlineAt == null);
+        registrations.Should().OnlyContain(r => r.TeamAssignment == "Black" || r.TeamAssignment == "White");
+        registrations.Select(r => r.TeamAssignment).Distinct().Should().HaveCount(2, "team assignments should be balanced");
+        result.RegisteredCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithAutoRoster_FreeEvent_RegistersMembersWithoutPaymentStatus()
+    {
+        // Arrange
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("regular@example.com");
+        await CreateSubscription(org.Id, user.Id);
+        await AddAutoRosterMember(org.Id, user.Id, "Skater", 0);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id, cost: 0), admin.Id);
+
+        // Assert
+        var registration = await _context.EventRegistrations
+            .SingleAsync(r => r.EventId == result.Id && r.UserId == user.Id);
+        registration.Status.Should().Be("Registered");
+        registration.PaymentStatus.Should().BeNull();
+        registration.RegisteredPosition.Should().Be("Skater");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithAutoRoster_GoaliesDoNotConsumeSkaterSlots()
+    {
+        // Arrange - MaxPlayers=1: one skater fills the roster, goalie listed after must still roster
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var skater = await CreateTestUser("skater@example.com");
+        var goalie = await CreateTestUser("goalie@example.com", new Dictionary<string, string> { { "goalie", "Gold" } });
+        await CreateSubscription(org.Id, skater.Id);
+        await CreateSubscription(org.Id, goalie.Id);
+        await AddAutoRosterMember(org.Id, skater.Id, "Skater", 0);
+        await AddAutoRosterMember(org.Id, goalie.Id, "Goalie", 1);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id, maxPlayers: 1), admin.Id);
+
+        // Assert
+        var skaterReg = await _context.EventRegistrations
+            .SingleAsync(r => r.EventId == result.Id && r.UserId == skater.Id);
+        var goalieReg = await _context.EventRegistrations
+            .SingleAsync(r => r.EventId == result.Id && r.UserId == goalie.Id);
+        skaterReg.Status.Should().Be("Registered");
+        goalieReg.Status.Should().Be("Registered", "goalies never count against MaxPlayers");
+        goalieReg.RegisteredPosition.Should().Be("Goalie");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithAutoRoster_OverflowSkatersWaitlistedInListOrder()
+    {
+        // Arrange - MaxPlayers=1 with 3 skaters: first rosters, rest waitlist in SortOrder
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("regular1@example.com");
+        var user2 = await CreateTestUser("regular2@example.com");
+        var user3 = await CreateTestUser("regular3@example.com");
+        await CreateSubscription(org.Id, user1.Id);
+        await CreateSubscription(org.Id, user2.Id);
+        await CreateSubscription(org.Id, user3.Id);
+        await AddAutoRosterMember(org.Id, user1.Id, "Skater", 0);
+        await AddAutoRosterMember(org.Id, user2.Id, "Skater", 1);
+        await AddAutoRosterMember(org.Id, user3.Id, "Skater", 2);
+
+        var nextWaitlistPosition = 0;
+        _mockWaitlistService.Setup(w => w.GetNextWaitlistPositionAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(() => ++nextWaitlistPosition);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id, maxPlayers: 1), admin.Id);
+
+        // Assert
+        var reg1 = await _context.EventRegistrations.SingleAsync(r => r.EventId == result.Id && r.UserId == user1.Id);
+        var reg2 = await _context.EventRegistrations.SingleAsync(r => r.EventId == result.Id && r.UserId == user2.Id);
+        var reg3 = await _context.EventRegistrations.SingleAsync(r => r.EventId == result.Id && r.UserId == user3.Id);
+        reg1.Status.Should().Be("Registered");
+        reg2.Status.Should().Be("Waitlisted");
+        reg2.WaitlistPosition.Should().Be(1);
+        reg2.TeamAssignment.Should().BeNull();
+        reg3.Status.Should().Be("Waitlisted");
+        reg3.WaitlistPosition.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithApplyAutoRosterFalse_AddsNoRegistrations()
+    {
+        // Arrange
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("regular@example.com");
+        await CreateSubscription(org.Id, user.Id);
+        await AddAutoRosterMember(org.Id, user.Id, "Skater", 0);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id, applyAutoRoster: false), admin.Id);
+
+        // Assert
+        var registrations = await _context.EventRegistrations
+            .Where(r => r.EventId == result.Id)
+            .ToListAsync();
+        registrations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithAutoRoster_SkipsUnsubscribedMembers()
+    {
+        // Arrange - user2 was in the list but unsubscribed from the org
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("regular1@example.com");
+        var user2 = await CreateTestUser("unsubscribed@example.com");
+        await CreateSubscription(org.Id, user1.Id);
+        await AddAutoRosterMember(org.Id, user1.Id, "Skater", 0);
+        await AddAutoRosterMember(org.Id, user2.Id, "Skater", 1);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id), admin.Id);
+
+        // Assert
+        var registrations = await _context.EventRegistrations
+            .Where(r => r.EventId == result.Id)
+            .ToListAsync();
+        registrations.Should().ContainSingle(r => r.UserId == user1.Id);
+        registrations.Should().NotContain(r => r.UserId == user2.Id);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithAutoRoster_SkipsInactiveMembers()
+    {
+        // Arrange
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var activeUser = await CreateTestUser("active@example.com");
+        var inactiveUser = await CreateTestUser("inactive@example.com");
+        inactiveUser.IsActive = false;
+        await _context.SaveChangesAsync();
+        await CreateSubscription(org.Id, activeUser.Id);
+        await CreateSubscription(org.Id, inactiveUser.Id);
+        await AddAutoRosterMember(org.Id, inactiveUser.Id, "Skater", 0);
+        await AddAutoRosterMember(org.Id, activeUser.Id, "Skater", 1);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id), admin.Id);
+
+        // Assert
+        var registrations = await _context.EventRegistrations
+            .Where(r => r.EventId == result.Id)
+            .ToListAsync();
+        registrations.Should().ContainSingle(r => r.UserId == activeUser.Id);
+        registrations.Should().NotContain(r => r.UserId == inactiveUser.Id);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithAutoRoster_UnpublishedRoster_SendsNoRosterNotifications()
+    {
+        // Arrange - new events start with IsRosterPublished=false, so added_to_roster pushes are suppressed
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("regular@example.com");
+        user.PushToken = "ExponentPushToken[test]";
+        await _context.SaveChangesAsync();
+        await CreateSubscription(org.Id, user.Id);
+        await AddAutoRosterMember(org.Id, user.Id, "Skater", 0);
+
+        // Act
+        await _sut.CreateAsync(CreateEventRequestFor(org.Id), admin.Id);
+
+        // Assert - no direct pushes (the org-wide new_event notification uses NotifyOrganizationSubscribersAsync)
+        _mockNotificationService.Verify(n => n.SendPushNotificationAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<object?>(),
+            It.IsAny<Guid?>(), It.IsAny<string?>(), It.IsAny<Guid?>(), It.IsAny<Guid?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithEmptyAutoRoster_CreatesEventNormally()
+    {
+        // Arrange
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+
+        // Act
+        var result = await _sut.CreateAsync(CreateEventRequestFor(org.Id), admin.Id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.RegisteredCount.Should().Be(0);
+    }
+
     #endregion
 
     #region Registration Tests

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationAutoRosterServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationAutoRosterServiceTests.cs
@@ -1,0 +1,378 @@
+using BHMHockey.Api.Data;
+using BHMHockey.Api.Models.Entities;
+using BHMHockey.Api.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace BHMHockey.Api.Tests.Services;
+
+/// <summary>
+/// Tests for OrganizationAutoRosterService - protecting the org "regulars" list.
+/// These tests ensure:
+/// - Only org admins can view or manage the auto-roster
+/// - Adds are restricted to current subscribers with valid positions, no duplicates
+/// - New members append at the end of the order
+/// - Reordering validates completeness and persists new sort orders
+/// </summary>
+public class OrganizationAutoRosterServiceTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly OrganizationAdminService _adminService;
+    private readonly OrganizationAutoRosterService _sut;
+
+    public OrganizationAutoRosterServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+        _adminService = new OrganizationAdminService(_context);
+        _sut = new OrganizationAutoRosterService(_context, _adminService, Mock.Of<ILogger<OrganizationAutoRosterService>>());
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    #region Helper Methods
+
+    private async Task<User> CreateTestUser(string email = "user@example.com", Dictionary<string, string>? positions = null)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            PasswordHash = "hashed_password",
+            FirstName = "Test",
+            LastName = "User",
+            Positions = positions ?? new Dictionary<string, string> { { "skater", "Silver" } },
+            Role = "Player",
+            IsActive = true
+        };
+
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task<Organization> CreateTestOrganization(Guid creatorId, string name = "Test Org")
+    {
+        var org = new Organization
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            CreatorId = creatorId,
+            IsActive = true
+        };
+        _context.Organizations.Add(org);
+
+        _context.OrganizationAdmins.Add(new OrganizationAdmin
+        {
+            OrganizationId = org.Id,
+            UserId = creatorId
+        });
+
+        await _context.SaveChangesAsync();
+        return org;
+    }
+
+    private async Task Subscribe(Guid orgId, Guid userId)
+    {
+        _context.OrganizationSubscriptions.Add(new OrganizationSubscription
+        {
+            OrganizationId = orgId,
+            UserId = userId
+        });
+        await _context.SaveChangesAsync();
+    }
+
+    #endregion
+
+    #region Authorization Tests
+
+    [Fact]
+    public async Task GetAutoRosterAsync_AsNonAdmin_ThrowsUnauthorized()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var nonAdmin = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+
+        var act = () => _sut.GetAutoRosterAsync(org.Id, nonAdmin.Id);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task AddMemberAsync_AsNonAdmin_ThrowsUnauthorized()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var nonAdmin = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await Subscribe(org.Id, nonAdmin.Id);
+
+        var act = () => _sut.AddMemberAsync(org.Id, nonAdmin.Id, "Skater", nonAdmin.Id);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task RemoveMemberAsync_AsNonAdmin_ThrowsUnauthorized()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var nonAdmin = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+
+        var act = () => _sut.RemoveMemberAsync(org.Id, nonAdmin.Id, nonAdmin.Id);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    [Fact]
+    public async Task ReorderAsync_AsNonAdmin_ThrowsUnauthorized()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var nonAdmin = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+
+        var act = () => _sut.ReorderAsync(org.Id, new List<Guid>(), nonAdmin.Id);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+    }
+
+    #endregion
+
+    #region Add Tests
+
+    [Fact]
+    public async Task AddMemberAsync_WithSubscriber_AddsAtEndOfOrder()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("user1@example.com");
+        var user2 = await CreateTestUser("user2@example.com");
+        await Subscribe(org.Id, user1.Id);
+        await Subscribe(org.Id, user2.Id);
+
+        var first = await _sut.AddMemberAsync(org.Id, user1.Id, "Skater", admin.Id);
+        var second = await _sut.AddMemberAsync(org.Id, user2.Id, "Goalie", admin.Id);
+
+        first.SortOrder.Should().Be(0);
+        second.SortOrder.Should().Be(1);
+        second.Position.Should().Be("Goalie");
+        second.UserId.Should().Be(user2.Id);
+
+        var saved = await _context.OrganizationAutoRosterMembers
+            .FirstOrDefaultAsync(m => m.OrganizationId == org.Id && m.UserId == user2.Id);
+        saved.Should().NotBeNull();
+        saved!.AddedByUserId.Should().Be(admin.Id);
+    }
+
+    [Fact]
+    public async Task AddMemberAsync_WithNonSubscriber_ThrowsInvalidOperation()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var nonSubscriber = await CreateTestUser("outsider@example.com");
+
+        var act = () => _sut.AddMemberAsync(org.Id, nonSubscriber.Id, "Skater", admin.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*member of this organization*");
+    }
+
+    [Fact]
+    public async Task AddMemberAsync_WithDuplicateUser_ThrowsInvalidOperation()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("user@example.com");
+        await Subscribe(org.Id, user.Id);
+        await _sut.AddMemberAsync(org.Id, user.Id, "Skater", admin.Id);
+
+        var act = () => _sut.AddMemberAsync(org.Id, user.Id, "Goalie", admin.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*already in the auto-roster*");
+    }
+
+    [Fact]
+    public async Task AddMemberAsync_WithInvalidPosition_ThrowsInvalidOperation()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("user@example.com");
+        await Subscribe(org.Id, user.Id);
+
+        var act = () => _sut.AddMemberAsync(org.Id, user.Id, "Defense", admin.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Invalid position*");
+    }
+
+    [Fact]
+    public async Task AddMemberAsync_NormalizesPositionCasing()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("user@example.com");
+        await Subscribe(org.Id, user.Id);
+
+        var result = await _sut.AddMemberAsync(org.Id, user.Id, "goalie", admin.Id);
+
+        result.Position.Should().Be("Goalie");
+    }
+
+    [Fact]
+    public async Task AddMemberAsync_DoesNotValidateAgainstProfilePositions()
+    {
+        // Organizer semantics: admin can list a skater-only user as a goalie
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("user@example.com", new Dictionary<string, string> { { "skater", "Silver" } });
+        await Subscribe(org.Id, user.Id);
+
+        var result = await _sut.AddMemberAsync(org.Id, user.Id, "Goalie", admin.Id);
+
+        result.Position.Should().Be("Goalie");
+    }
+
+    #endregion
+
+    #region Get Tests
+
+    [Fact]
+    public async Task GetAutoRosterAsync_ReturnsMembersOrderedBySortOrder()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("user1@example.com");
+        var user2 = await CreateTestUser("user2@example.com");
+        await Subscribe(org.Id, user1.Id);
+        await Subscribe(org.Id, user2.Id);
+        await _sut.AddMemberAsync(org.Id, user1.Id, "Skater", admin.Id);
+        await _sut.AddMemberAsync(org.Id, user2.Id, "Goalie", admin.Id);
+        await _sut.ReorderAsync(org.Id, new List<Guid> { user2.Id, user1.Id }, admin.Id);
+
+        var result = await _sut.GetAutoRosterAsync(org.Id, admin.Id);
+
+        result.Should().HaveCount(2);
+        result[0].UserId.Should().Be(user2.Id);
+        result[1].UserId.Should().Be(user1.Id);
+        result[0].FirstName.Should().Be("Test");
+        result[0].Positions.Should().ContainKey("skater");
+    }
+
+    [Fact]
+    public async Task GetAutoRosterAsync_WithEmptyList_ReturnsEmpty()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+
+        var result = await _sut.GetAutoRosterAsync(org.Id, admin.Id);
+
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Remove Tests
+
+    [Fact]
+    public async Task RemoveMemberAsync_WithExistingMember_RemovesAndReturnsTrue()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("user@example.com");
+        await Subscribe(org.Id, user.Id);
+        await _sut.AddMemberAsync(org.Id, user.Id, "Skater", admin.Id);
+
+        var result = await _sut.RemoveMemberAsync(org.Id, user.Id, admin.Id);
+
+        result.Should().BeTrue();
+        var remaining = await _context.OrganizationAutoRosterMembers
+            .Where(m => m.OrganizationId == org.Id)
+            .ToListAsync();
+        remaining.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveMemberAsync_WithNonMember_ReturnsFalse()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user = await CreateTestUser("user@example.com");
+
+        var result = await _sut.RemoveMemberAsync(org.Id, user.Id, admin.Id);
+
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Reorder Tests
+
+    [Fact]
+    public async Task ReorderAsync_WithAllMembers_PersistsNewOrder()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("user1@example.com");
+        var user2 = await CreateTestUser("user2@example.com");
+        var user3 = await CreateTestUser("user3@example.com");
+        await Subscribe(org.Id, user1.Id);
+        await Subscribe(org.Id, user2.Id);
+        await Subscribe(org.Id, user3.Id);
+        await _sut.AddMemberAsync(org.Id, user1.Id, "Skater", admin.Id);
+        await _sut.AddMemberAsync(org.Id, user2.Id, "Skater", admin.Id);
+        await _sut.AddMemberAsync(org.Id, user3.Id, "Skater", admin.Id);
+
+        var result = await _sut.ReorderAsync(org.Id, new List<Guid> { user3.Id, user1.Id, user2.Id }, admin.Id);
+
+        result.Select(m => m.UserId).Should().ContainInOrder(user3.Id, user1.Id, user2.Id);
+
+        var saved = await _context.OrganizationAutoRosterMembers
+            .Where(m => m.OrganizationId == org.Id)
+            .OrderBy(m => m.SortOrder)
+            .ToListAsync();
+        saved.Select(m => m.UserId).Should().ContainInOrder(user3.Id, user1.Id, user2.Id);
+    }
+
+    [Fact]
+    public async Task ReorderAsync_WithMissingMember_ThrowsInvalidOperation()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("user1@example.com");
+        var user2 = await CreateTestUser("user2@example.com");
+        await Subscribe(org.Id, user1.Id);
+        await Subscribe(org.Id, user2.Id);
+        await _sut.AddMemberAsync(org.Id, user1.Id, "Skater", admin.Id);
+        await _sut.AddMemberAsync(org.Id, user2.Id, "Skater", admin.Id);
+
+        var act = () => _sut.ReorderAsync(org.Id, new List<Guid> { user1.Id }, admin.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*All auto-roster members*");
+    }
+
+    [Fact]
+    public async Task ReorderAsync_WithUnknownUser_ThrowsInvalidOperation()
+    {
+        var admin = await CreateTestUser("admin@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var user1 = await CreateTestUser("user1@example.com");
+        await Subscribe(org.Id, user1.Id);
+        await _sut.AddMemberAsync(org.Id, user1.Id, "Skater", admin.Id);
+
+        var act = () => _sut.ReorderAsync(org.Id, new List<Guid> { user1.Id, Guid.NewGuid() }, admin.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*All auto-roster members*");
+    }
+
+    #endregion
+}

--- a/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
@@ -12,11 +12,19 @@ public class OrganizationsController : ControllerBase
 {
     private readonly IOrganizationService _organizationService;
     private readonly IOrganizationAdminService _adminService;
+    private readonly IOrganizationAutoRosterService _autoRosterService;
+    private readonly ILogger<OrganizationsController> _logger;
 
-    public OrganizationsController(IOrganizationService organizationService, IOrganizationAdminService adminService)
+    public OrganizationsController(
+        IOrganizationService organizationService,
+        IOrganizationAdminService adminService,
+        IOrganizationAutoRosterService autoRosterService,
+        ILogger<OrganizationsController> logger)
     {
         _organizationService = organizationService;
         _adminService = adminService;
+        _autoRosterService = autoRosterService;
+        _logger = logger;
     }
 
     private Guid? GetCurrentUserIdOrNull()
@@ -253,6 +261,105 @@ public class OrganizationsController : ControllerBase
         }
         catch (InvalidOperationException ex)
         {
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    // Auto-roster endpoints - org "regulars" auto-added to new org events
+
+    /// <summary>
+    /// Get the organization's auto-roster list ordered by sort order. Only admins can access.
+    /// </summary>
+    [HttpGet("{id:guid}/auto-roster")]
+    [Authorize]
+    public async Task<ActionResult<List<AutoRosterMemberDto>>> GetAutoRoster(Guid id)
+    {
+        try
+        {
+            var userId = GetCurrentUserId();
+            var members = await _autoRosterService.GetAutoRosterAsync(id, userId);
+            return Ok(members);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogWarning("Get auto-roster denied for organization {OrganizationId}: requester is not an admin", id);
+            return Forbid();
+        }
+    }
+
+    /// <summary>
+    /// Add a subscriber to the organization's auto-roster. Only admins can add.
+    /// </summary>
+    [HttpPost("{id:guid}/auto-roster")]
+    [Authorize]
+    public async Task<ActionResult<AutoRosterMemberDto>> AddAutoRosterMember(Guid id, [FromBody] AddAutoRosterMemberRequest request)
+    {
+        try
+        {
+            var userId = GetCurrentUserId();
+            var member = await _autoRosterService.AddMemberAsync(id, request.UserId, request.Position, userId);
+            return Ok(member);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogWarning("Add auto-roster member denied for organization {OrganizationId}: requester is not an admin", id);
+            return Forbid();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Add auto-roster member rejected for organization {OrganizationId}: {Message}", id, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Remove a user from the organization's auto-roster. Only admins can remove.
+    /// </summary>
+    [HttpDelete("{id:guid}/auto-roster/{memberUserId:guid}")]
+    [Authorize]
+    public async Task<IActionResult> RemoveAutoRosterMember(Guid id, Guid memberUserId)
+    {
+        try
+        {
+            var userId = GetCurrentUserId();
+            var removed = await _autoRosterService.RemoveMemberAsync(id, memberUserId, userId);
+
+            if (!removed)
+            {
+                _logger.LogWarning("Remove auto-roster member failed for organization {OrganizationId}: user {MemberUserId} not in list", id, memberUserId);
+                return NotFound(new { message = "User is not in the auto-roster" });
+            }
+
+            return NoContent();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogWarning("Remove auto-roster member denied for organization {OrganizationId}: requester is not an admin", id);
+            return Forbid();
+        }
+    }
+
+    /// <summary>
+    /// Reorder the organization's auto-roster. All current members must be included. Only admins can reorder.
+    /// </summary>
+    [HttpPut("{id:guid}/auto-roster/order")]
+    [Authorize]
+    public async Task<ActionResult<List<AutoRosterMemberDto>>> ReorderAutoRoster(Guid id, [FromBody] ReorderAutoRosterRequest request)
+    {
+        try
+        {
+            var userId = GetCurrentUserId();
+            var members = await _autoRosterService.ReorderAsync(id, request.OrderedUserIds, userId);
+            return Ok(members);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogWarning("Reorder auto-roster denied for organization {OrganizationId}: requester is not an admin", id);
+            return Forbid();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Reorder auto-roster rejected for organization {OrganizationId}: {Message}", id, ex.Message);
             return BadRequest(new { message = ex.Message });
         }
     }

--- a/apps/api/BHMHockey.Api/Data/AppDbContext.cs
+++ b/apps/api/BHMHockey.Api/Data/AppDbContext.cs
@@ -17,6 +17,7 @@ public class AppDbContext : DbContext
     public DbSet<Organization> Organizations { get; set; }
     public DbSet<OrganizationSubscription> OrganizationSubscriptions { get; set; }
     public DbSet<OrganizationAdmin> OrganizationAdmins { get; set; }
+    public DbSet<OrganizationAutoRosterMember> OrganizationAutoRosterMembers { get; set; }
     public DbSet<Event> Events { get; set; }
     public DbSet<EventRegistration> EventRegistrations { get; set; }
     public DbSet<Notification> Notifications { get; set; }
@@ -127,6 +128,26 @@ public class AppDbContext : DbContext
             entity.HasIndex(e => new { e.OrganizationId, e.UserId }).IsUnique();
             entity.HasOne(e => e.Organization)
                 .WithMany(o => o.Admins)
+                .HasForeignKey(e => e.OrganizationId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne(e => e.AddedByUser)
+                .WithMany()
+                .HasForeignKey(e => e.AddedByUserId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // OrganizationAutoRosterMember configuration
+        modelBuilder.Entity<OrganizationAutoRosterMember>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasIndex(e => new { e.OrganizationId, e.UserId }).IsUnique();
+            entity.Property(e => e.Position).IsRequired().HasMaxLength(50);
+            entity.HasOne(e => e.Organization)
+                .WithMany()
                 .HasForeignKey(e => e.OrganizationId)
                 .OnDelete(DeleteBehavior.Cascade);
             entity.HasOne(e => e.User)

--- a/apps/api/BHMHockey.Api/Migrations/20260717030625_AddOrganizationAutoRoster.Designer.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717030625_AddOrganizationAutoRoster.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BHMHockey.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHMHockey.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717030625_AddOrganizationAutoRoster")]
+    partial class AddOrganizationAutoRoster
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/BHMHockey.Api/Migrations/20260717030625_AddOrganizationAutoRoster.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717030625_AddOrganizationAutoRoster.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHMHockey.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationAutoRoster : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OrganizationAutoRosterMembers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Position = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    SortOrder = table.Column<int>(type: "integer", nullable: false),
+                    AddedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    AddedByUserId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizationAutoRosterMembers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrganizationAutoRosterMembers_Organizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "Organizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrganizationAutoRosterMembers_Users_AddedByUserId",
+                        column: x => x.AddedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_OrganizationAutoRosterMembers_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationAutoRosterMembers_AddedByUserId",
+                table: "OrganizationAutoRosterMembers",
+                column: "AddedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationAutoRosterMembers_OrganizationId_UserId",
+                table: "OrganizationAutoRosterMembers",
+                columns: new[] { "OrganizationId", "UserId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationAutoRosterMembers_UserId",
+                table: "OrganizationAutoRosterMembers",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrganizationAutoRosterMembers");
+        }
+    }
+}

--- a/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
@@ -49,7 +49,8 @@ public record CreateEventRequest(
     string? Venue = null,
     DateTime? RegistrationDeadline = null,
     string? Visibility = "Public",       // Default to public if not specified
-    List<string>? SkillLevels = null     // Optional - overrides org's skill levels if set
+    List<string>? SkillLevels = null,    // Optional - overrides org's skill levels if set
+    bool ApplyAutoRoster = true          // Auto-add the org's auto-roster members (ignored for standalone events)
 );
 
 public record UpdateEventRequest(

--- a/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
@@ -84,3 +84,24 @@ public record OrganizationAdminDto(
 public record AddAdminRequest(
     Guid UserId
 );
+
+// Auto-roster DTOs - org "regulars" auto-added to new org events
+public record AutoRosterMemberDto(
+    Guid Id,
+    Guid UserId,
+    string FirstName,
+    string LastName,
+    Dictionary<string, string>? Positions,  // User's profile positions {"goalie": "Gold", "skater": "Silver"}
+    string Position,                        // "Goalie" or "Skater" - position they'll be auto-added as
+    int SortOrder,
+    DateTime AddedAt
+);
+
+public record AddAutoRosterMemberRequest(
+    Guid UserId,
+    string Position                         // "Goalie" or "Skater"
+);
+
+public record ReorderAutoRosterRequest(
+    List<Guid> OrderedUserIds               // All auto-roster member user IDs in the new order
+);

--- a/apps/api/BHMHockey.Api/Models/Entities/OrganizationAutoRosterMember.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/OrganizationAutoRosterMember.cs
@@ -1,0 +1,15 @@
+namespace BHMHockey.Api.Models.Entities;
+
+public class OrganizationAutoRosterMember
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid OrganizationId { get; set; }
+    public Organization Organization { get; set; } = null!;
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+    public string Position { get; set; } = "Skater"; // "Goalie" or "Skater"
+    public int SortOrder { get; set; }
+    public DateTime AddedAt { get; set; } = DateTime.UtcNow;
+    public Guid? AddedByUserId { get; set; }
+    public User? AddedByUser { get; set; }
+}

--- a/apps/api/BHMHockey.Api/Program.cs
+++ b/apps/api/BHMHockey.Api/Program.cs
@@ -126,6 +126,7 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IOrganizationService, OrganizationService>();
 builder.Services.AddScoped<IOrganizationAdminService, OrganizationAdminService>();
+builder.Services.AddScoped<IOrganizationAutoRosterService, OrganizationAutoRosterService>();
 builder.Services.AddScoped<IEventService, EventService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IWaitlistService, WaitlistService>();

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -123,6 +123,13 @@ public class EventService : IEventService
         {
             evt.Organization = await _context.Organizations.FindAsync(evt.OrganizationId.Value);
 
+            // Auto-add the org's regulars before subscribers are notified,
+            // so they're placed before anyone else can register
+            if (request.ApplyAutoRoster)
+            {
+                await ApplyAutoRosterAsync(evt);
+            }
+
             // Notify organization subscribers about the new game
             var orgName = evt.Organization?.Name ?? "An organization";
             var venueText = !string.IsNullOrWhiteSpace(evt.Venue) ? $" - {evt.Venue}" : "";
@@ -139,6 +146,96 @@ public class EventService : IEventService
         }
 
         return await MapToDto(evt, creatorId);
+    }
+
+    /// <summary>
+    /// Auto-adds the organization's auto-roster members to a newly created org event.
+    /// Mirrors organizer manual adds (AddUserToWaitlistAsync): positions are not validated
+    /// against user profiles, paid events do NOT force waitlisting, and no payment deadline is set.
+    /// Goalies always go direct to roster (they never count against MaxPlayers); skaters fill
+    /// the roster in list order and overflow to the waitlist.
+    /// </summary>
+    private async Task ApplyAutoRosterAsync(Event evt)
+    {
+        var autoRosterMembers = await _context.OrganizationAutoRosterMembers
+            .Include(m => m.User)
+            .Where(m => m.OrganizationId == evt.OrganizationId!.Value)
+            .OrderBy(m => m.SortOrder)
+            .ToListAsync();
+
+        if (autoRosterMembers.Count == 0)
+        {
+            return;
+        }
+
+        var subscriberIds = (await _context.OrganizationSubscriptions
+            .Where(s => s.OrganizationId == evt.OrganizationId!.Value)
+            .Select(s => s.UserId)
+            .ToListAsync()).ToHashSet();
+
+        var isPaidEvent = evt.Cost > 0;
+        var skaterCount = await _context.EventRegistrations
+            .CountAsync(r => r.EventId == evt.Id && r.Status == "Registered" && r.RegisteredPosition != "Goalie");
+
+        foreach (var member in autoRosterMembers)
+        {
+            if (!member.User.IsActive || !subscriberIds.Contains(member.UserId))
+            {
+                _logger.LogInformation(
+                    "Auto-roster: skipped user {UserId} for event {EventId} (inactive or no longer subscribed)",
+                    member.UserId, evt.Id);
+                continue;
+            }
+
+            var alreadyRegistered = await _context.EventRegistrations
+                .AnyAsync(r => r.EventId == evt.Id && r.UserId == member.UserId
+                    && (r.Status == "Registered" || r.Status == "Waitlisted"));
+            if (alreadyRegistered)
+            {
+                continue;
+            }
+
+            var isGoalie = member.Position == "Goalie";
+            var registration = new EventRegistration
+            {
+                EventId = evt.Id,
+                UserId = member.UserId,
+                RegisteredPosition = member.Position,
+                PaymentStatus = isPaidEvent ? "Pending" : null
+            };
+
+            if (isGoalie || skaterCount < evt.MaxPlayers)
+            {
+                registration.Status = "Registered";
+                registration.TeamAssignment = await DetermineTeamAssignmentAsync(evt.Id, member.Position);
+                if (!isGoalie)
+                {
+                    skaterCount++;
+                }
+            }
+            else
+            {
+                registration.Status = "Waitlisted";
+                registration.WaitlistPosition = await _waitlistService.GetNextWaitlistPositionAsync(evt.Id);
+            }
+
+            _context.EventRegistrations.Add(registration);
+            // Save per member so team balancing and waitlist positions see prior rows
+            await _context.SaveChangesAsync();
+
+            // Same notification gating as manual organizer adds
+            if (evt.IsRosterPublished)
+            {
+                if (registration.Status == "Registered")
+                {
+                    await NotifyUserAddedToRosterAsync(evt, member.User, registration.TeamAssignment);
+                }
+                else
+                {
+                    await NotifyUserAddedToWaitlistAsync(evt, member.User, registration.WaitlistPosition ?? 1);
+                }
+            }
+        }
     }
 
     public async Task<List<EventDto>> GetAllAsync(Guid? currentUserId = null)

--- a/apps/api/BHMHockey.Api/Services/IOrganizationAutoRosterService.cs
+++ b/apps/api/BHMHockey.Api/Services/IOrganizationAutoRosterService.cs
@@ -1,0 +1,26 @@
+using BHMHockey.Api.Models.DTOs;
+
+namespace BHMHockey.Api.Services;
+
+public interface IOrganizationAutoRosterService
+{
+    /// <summary>
+    /// Get the organization's auto-roster list ordered by SortOrder. Admin only.
+    /// </summary>
+    Task<List<AutoRosterMemberDto>> GetAutoRosterAsync(Guid organizationId, Guid requesterId);
+
+    /// <summary>
+    /// Add a subscriber to the auto-roster list at the end of the order. Admin only.
+    /// </summary>
+    Task<AutoRosterMemberDto> AddMemberAsync(Guid organizationId, Guid userId, string position, Guid requesterId);
+
+    /// <summary>
+    /// Remove a user from the auto-roster list. Admin only. Returns false if not in the list.
+    /// </summary>
+    Task<bool> RemoveMemberAsync(Guid organizationId, Guid userId, Guid requesterId);
+
+    /// <summary>
+    /// Reorder the auto-roster list. All current members must be included. Admin only.
+    /// </summary>
+    Task<List<AutoRosterMemberDto>> ReorderAsync(Guid organizationId, List<Guid> orderedUserIds, Guid requesterId);
+}

--- a/apps/api/BHMHockey.Api/Services/OrganizationAutoRosterService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationAutoRosterService.cs
@@ -1,0 +1,161 @@
+using BHMHockey.Api.Data;
+using BHMHockey.Api.Models.DTOs;
+using BHMHockey.Api.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace BHMHockey.Api.Services;
+
+public class OrganizationAutoRosterService : IOrganizationAutoRosterService
+{
+    private readonly AppDbContext _context;
+    private readonly IOrganizationAdminService _adminService;
+    private readonly ILogger<OrganizationAutoRosterService> _logger;
+
+    public OrganizationAutoRosterService(
+        AppDbContext context,
+        IOrganizationAdminService adminService,
+        ILogger<OrganizationAutoRosterService> logger)
+    {
+        _context = context;
+        _adminService = adminService;
+        _logger = logger;
+    }
+
+    public async Task<List<AutoRosterMemberDto>> GetAutoRosterAsync(Guid organizationId, Guid requesterId)
+    {
+        await EnsureAdminAsync(organizationId, requesterId);
+
+        var members = await _context.OrganizationAutoRosterMembers
+            .Include(m => m.User)
+            .Where(m => m.OrganizationId == organizationId)
+            .OrderBy(m => m.SortOrder)
+            .ToListAsync();
+
+        return members.Select(MapToDto).ToList();
+    }
+
+    public async Task<AutoRosterMemberDto> AddMemberAsync(Guid organizationId, Guid userId, string position, Guid requesterId)
+    {
+        await EnsureAdminAsync(organizationId, requesterId);
+
+        var normalizedPosition = NormalizePosition(position);
+
+        var isSubscriber = await _context.OrganizationSubscriptions
+            .AnyAsync(s => s.OrganizationId == organizationId && s.UserId == userId);
+        if (!isSubscriber)
+        {
+            _logger.LogWarning("Auto-roster add rejected: user {UserId} is not a subscriber of organization {OrganizationId}", userId, organizationId);
+            throw new InvalidOperationException("User must be a member of this organization");
+        }
+
+        var alreadyInList = await _context.OrganizationAutoRosterMembers
+            .AnyAsync(m => m.OrganizationId == organizationId && m.UserId == userId);
+        if (alreadyInList)
+        {
+            _logger.LogWarning("Auto-roster add rejected: user {UserId} is already in the auto-roster for organization {OrganizationId}", userId, organizationId);
+            throw new InvalidOperationException("User is already in the auto-roster");
+        }
+
+        var maxSortOrder = await _context.OrganizationAutoRosterMembers
+            .Where(m => m.OrganizationId == organizationId)
+            .MaxAsync(m => (int?)m.SortOrder) ?? -1;
+
+        var member = new OrganizationAutoRosterMember
+        {
+            OrganizationId = organizationId,
+            UserId = userId,
+            Position = normalizedPosition,
+            SortOrder = maxSortOrder + 1,
+            AddedByUserId = requesterId
+        };
+
+        _context.OrganizationAutoRosterMembers.Add(member);
+        await _context.SaveChangesAsync();
+
+        await _context.Entry(member).Reference(m => m.User).LoadAsync();
+
+        return MapToDto(member);
+    }
+
+    public async Task<bool> RemoveMemberAsync(Guid organizationId, Guid userId, Guid requesterId)
+    {
+        await EnsureAdminAsync(organizationId, requesterId);
+
+        var member = await _context.OrganizationAutoRosterMembers
+            .FirstOrDefaultAsync(m => m.OrganizationId == organizationId && m.UserId == userId);
+
+        if (member == null)
+        {
+            _logger.LogWarning("Auto-roster remove failed: user {UserId} not in auto-roster for organization {OrganizationId}", userId, organizationId);
+            return false;
+        }
+
+        _context.OrganizationAutoRosterMembers.Remove(member);
+        await _context.SaveChangesAsync();
+
+        return true;
+    }
+
+    public async Task<List<AutoRosterMemberDto>> ReorderAsync(Guid organizationId, List<Guid> orderedUserIds, Guid requesterId)
+    {
+        await EnsureAdminAsync(organizationId, requesterId);
+
+        var members = await _context.OrganizationAutoRosterMembers
+            .Include(m => m.User)
+            .Where(m => m.OrganizationId == organizationId)
+            .ToListAsync();
+
+        var orderedIdSet = orderedUserIds.ToHashSet();
+        var memberIdSet = members.Select(m => m.UserId).ToHashSet();
+        if (orderedUserIds.Count != orderedIdSet.Count || !orderedIdSet.SetEquals(memberIdSet))
+        {
+            _logger.LogWarning("Auto-roster reorder rejected for organization {OrganizationId}: ordered list does not match current members", organizationId);
+            throw new InvalidOperationException("All auto-roster members must be included exactly once");
+        }
+
+        var membersByUserId = members.ToDictionary(m => m.UserId);
+        for (var i = 0; i < orderedUserIds.Count; i++)
+        {
+            membersByUserId[orderedUserIds[i]].SortOrder = i;
+        }
+
+        await _context.SaveChangesAsync();
+
+        return members.OrderBy(m => m.SortOrder).Select(MapToDto).ToList();
+    }
+
+    private async Task EnsureAdminAsync(Guid organizationId, Guid requesterId)
+    {
+        var isAdmin = await _adminService.IsUserAdminAsync(organizationId, requesterId);
+        if (!isAdmin)
+        {
+            _logger.LogWarning("Auto-roster access denied: user {RequesterId} is not an admin of organization {OrganizationId}", requesterId, organizationId);
+            throw new UnauthorizedAccessException("You don't have permission to manage this organization's auto-roster");
+        }
+    }
+
+    private static string NormalizePosition(string? position)
+    {
+        var normalized = position?.ToLowerInvariant();
+        if (normalized != "goalie" && normalized != "skater")
+        {
+            throw new InvalidOperationException("Invalid position. Must be 'Goalie' or 'Skater'");
+        }
+
+        return normalized == "goalie" ? "Goalie" : "Skater";
+    }
+
+    private static AutoRosterMemberDto MapToDto(OrganizationAutoRosterMember member)
+    {
+        return new AutoRosterMemberDto(
+            member.Id,
+            member.UserId,
+            member.User.FirstName,
+            member.User.LastName,
+            member.User.Positions,
+            member.Position,
+            member.SortOrder,
+            member.AddedAt
+        );
+    }
+}

--- a/apps/mobile/__tests__/stores/organizationStore.test.ts
+++ b/apps/mobile/__tests__/stores/organizationStore.test.ts
@@ -8,6 +8,10 @@ const mockGetAll = jest.fn();
 const mockGetMySubscriptions = jest.fn();
 const mockSubscribe = jest.fn();
 const mockUnsubscribe = jest.fn();
+const mockGetAutoRoster = jest.fn();
+const mockAddAutoRosterMember = jest.fn();
+const mockRemoveAutoRosterMember = jest.fn();
+const mockReorderAutoRoster = jest.fn();
 
 // Mock the api-client module
 jest.mock('@bhmhockey/api-client', () => ({
@@ -16,12 +20,16 @@ jest.mock('@bhmhockey/api-client', () => ({
     getMySubscriptions: mockGetMySubscriptions,
     subscribe: mockSubscribe,
     unsubscribe: mockUnsubscribe,
+    getAutoRoster: mockGetAutoRoster,
+    addAutoRosterMember: mockAddAutoRosterMember,
+    removeAutoRosterMember: mockRemoveAutoRosterMember,
+    reorderAutoRoster: mockReorderAutoRoster,
   },
 }));
 
 // Import after mocking
 import { useOrganizationStore } from '../../stores/organizationStore';
-import type { Organization, OrganizationSubscription } from '@bhmhockey/shared';
+import type { Organization, OrganizationSubscription, AutoRosterMember } from '@bhmhockey/shared';
 
 const createMockOrg = (overrides: Partial<Organization> = {}): Organization => ({
   id: 'org-1',
@@ -44,6 +52,18 @@ const createMockSubscription = (org: Organization): OrganizationSubscription => 
   subscribedAt: new Date().toISOString(),
 });
 
+const createMockAutoRosterMember = (overrides: Partial<AutoRosterMember> = {}): AutoRosterMember => ({
+  id: 'member-1',
+  userId: 'user-1',
+  firstName: 'Test',
+  lastName: 'Player',
+  positions: { skater: 'Silver' },
+  position: 'Skater',
+  sortOrder: 0,
+  addedAt: new Date().toISOString(),
+  ...overrides,
+});
+
 describe('organizationStore', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -51,6 +71,9 @@ describe('organizationStore', () => {
     useOrganizationStore.setState({
       organizations: [],
       mySubscriptions: [],
+      autoRoster: [],
+      autoRosterOrgId: null,
+      members: [],
       isLoading: false,
       error: null,
     });
@@ -235,6 +258,110 @@ describe('organizationStore', () => {
       useOrganizationStore.getState().clearError();
 
       expect(useOrganizationStore.getState().error).toBeNull();
+    });
+  });
+
+  describe('fetchAutoRoster', () => {
+    it('sets autoRoster and org id on successful fetch', async () => {
+      const members = [createMockAutoRosterMember()];
+      mockGetAutoRoster.mockResolvedValue(members);
+
+      await useOrganizationStore.getState().fetchAutoRoster('org-1');
+
+      expect(mockGetAutoRoster).toHaveBeenCalledWith('org-1');
+      expect(useOrganizationStore.getState().autoRoster).toEqual(members);
+      expect(useOrganizationStore.getState().autoRosterOrgId).toBe('org-1');
+    });
+
+    it('sets error on fetch failure', async () => {
+      mockGetAutoRoster.mockRejectedValue(new Error('Forbidden'));
+
+      await useOrganizationStore.getState().fetchAutoRoster('org-1');
+
+      expect(useOrganizationStore.getState().error).toBe('Forbidden');
+    });
+  });
+
+  describe('addAutoRosterMember', () => {
+    it('appends the new member on success', async () => {
+      const existing = createMockAutoRosterMember({ userId: 'user-1', sortOrder: 0 });
+      useOrganizationStore.setState({ autoRoster: [existing], autoRosterOrgId: 'org-1' });
+      const added = createMockAutoRosterMember({ id: 'member-2', userId: 'user-2', sortOrder: 1, position: 'Goalie' });
+      mockAddAutoRosterMember.mockResolvedValue(added);
+
+      const result = await useOrganizationStore.getState().addAutoRosterMember('org-1', 'user-2', 'Goalie');
+
+      expect(result).toBe(true);
+      expect(mockAddAutoRosterMember).toHaveBeenCalledWith('org-1', { userId: 'user-2', position: 'Goalie' });
+      expect(useOrganizationStore.getState().autoRoster).toEqual([existing, added]);
+    });
+
+    it('sets error and returns false on failure', async () => {
+      mockAddAutoRosterMember.mockRejectedValue(new Error('User is already in the auto-roster'));
+
+      const result = await useOrganizationStore.getState().addAutoRosterMember('org-1', 'user-2', 'Skater');
+
+      expect(result).toBe(false);
+      expect(useOrganizationStore.getState().error).toBe('User is already in the auto-roster');
+      expect(useOrganizationStore.getState().autoRoster).toHaveLength(0);
+    });
+  });
+
+  describe('removeAutoRosterMember', () => {
+    it('optimistically removes the member', async () => {
+      const member1 = createMockAutoRosterMember({ userId: 'user-1' });
+      const member2 = createMockAutoRosterMember({ id: 'member-2', userId: 'user-2', sortOrder: 1 });
+      useOrganizationStore.setState({ autoRoster: [member1, member2] });
+      mockRemoveAutoRosterMember.mockResolvedValue(undefined);
+
+      const result = await useOrganizationStore.getState().removeAutoRosterMember('org-1', 'user-1');
+
+      expect(result).toBe(true);
+      expect(useOrganizationStore.getState().autoRoster).toEqual([member2]);
+    });
+
+    it('rolls back on failure', async () => {
+      const member = createMockAutoRosterMember({ userId: 'user-1' });
+      useOrganizationStore.setState({ autoRoster: [member] });
+      mockRemoveAutoRosterMember.mockRejectedValue(new Error('Remove failed'));
+
+      const result = await useOrganizationStore.getState().removeAutoRosterMember('org-1', 'user-1');
+
+      expect(result).toBe(false);
+      expect(useOrganizationStore.getState().autoRoster).toEqual([member]);
+      expect(useOrganizationStore.getState().error).toBe('Remove failed');
+    });
+  });
+
+  describe('reorderAutoRoster', () => {
+    it('applies the server order on success', async () => {
+      const member1 = createMockAutoRosterMember({ userId: 'user-1', sortOrder: 0 });
+      const member2 = createMockAutoRosterMember({ id: 'member-2', userId: 'user-2', sortOrder: 1 });
+      useOrganizationStore.setState({ autoRoster: [member1, member2] });
+      const reordered = [
+        { ...member2, sortOrder: 0 },
+        { ...member1, sortOrder: 1 },
+      ];
+      mockReorderAutoRoster.mockResolvedValue(reordered);
+
+      const result = await useOrganizationStore.getState().reorderAutoRoster('org-1', ['user-2', 'user-1']);
+
+      expect(result).toBe(true);
+      expect(mockReorderAutoRoster).toHaveBeenCalledWith('org-1', ['user-2', 'user-1']);
+      expect(useOrganizationStore.getState().autoRoster.map((m) => m.userId)).toEqual(['user-2', 'user-1']);
+    });
+
+    it('rolls back to the original order on failure', async () => {
+      const member1 = createMockAutoRosterMember({ userId: 'user-1', sortOrder: 0 });
+      const member2 = createMockAutoRosterMember({ id: 'member-2', userId: 'user-2', sortOrder: 1 });
+      useOrganizationStore.setState({ autoRoster: [member1, member2] });
+      mockReorderAutoRoster.mockRejectedValue(new Error('Reorder failed'));
+
+      const result = await useOrganizationStore.getState().reorderAutoRoster('org-1', ['user-2', 'user-1']);
+
+      expect(result).toBe(false);
+      expect(useOrganizationStore.getState().autoRoster.map((m) => m.userId)).toEqual(['user-1', 'user-2']);
+      expect(useOrganizationStore.getState().error).toBe('Reorder failed');
     });
   });
 

--- a/apps/mobile/app/events/create.tsx
+++ b/apps/mobile/app/events/create.tsx
@@ -28,6 +28,7 @@ export default function CreateEventScreen() {
       cost: data.cost,
       visibility: data.visibility,
       skillLevels: data.skillLevels,
+      applyAutoRoster: data.applyAutoRoster,
     });
 
     if (result) {

--- a/apps/mobile/app/organizations/[id].tsx
+++ b/apps/mobile/app/organizations/[id].tsx
@@ -380,6 +380,17 @@ export default function OrganizationDetailScreen() {
           </TouchableOpacity>
         )}
 
+        {/* Auto-Roster Button - visible to admins only */}
+        {isAdmin && (
+          <TouchableOpacity
+            style={styles.settingsButton}
+            onPress={() => router.push(`/organizations/${id}/auto-roster`)}
+          >
+            <Ionicons name="people-outline" size={20} color={colors.text.secondary} />
+            <Text style={styles.settingsButtonText}>Auto-Roster</Text>
+          </TouchableOpacity>
+        )}
+
         {/* Share Invite Button - visible to all members */}
         {(organization.isSubscribed || isAdmin) && (
           <TouchableOpacity

--- a/apps/mobile/app/organizations/[id]/auto-roster.tsx
+++ b/apps/mobile/app/organizations/[id]/auto-roster.tsx
@@ -1,0 +1,469 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  Modal,
+} from 'react-native';
+import { useLocalSearchParams, useRouter, Stack, useFocusEffect } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { organizationService } from '@bhmhockey/api-client';
+import type { OrganizationMember, Position } from '@bhmhockey/shared';
+import { useOrganizationStore } from '../../../stores/organizationStore';
+import { colors, spacing, radius } from '../../../theme';
+
+export default function AutoRosterScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+
+  const autoRoster = useOrganizationStore((state) => state.autoRoster);
+  const members = useOrganizationStore((state) => state.members);
+  const fetchAutoRoster = useOrganizationStore((state) => state.fetchAutoRoster);
+  const fetchMembers = useOrganizationStore((state) => state.fetchMembers);
+  const addAutoRosterMember = useOrganizationStore((state) => state.addAutoRosterMember);
+  const removeAutoRosterMember = useOrganizationStore((state) => state.removeAutoRosterMember);
+  const reorderAutoRoster = useOrganizationStore((state) => state.reorderAutoRoster);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [showAddModal, setShowAddModal] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadData();
+    }, [id])
+  );
+
+  const loadData = async () => {
+    if (!id) return;
+
+    setIsLoading(true);
+    try {
+      const org = await organizationService.getById(id);
+      if (!org.isAdmin) {
+        Alert.alert('Access Denied', 'Only organization admins can manage the auto-roster');
+        router.back();
+        return;
+      }
+      await Promise.all([fetchAutoRoster(id), fetchMembers(id)]);
+    } catch (error) {
+      Alert.alert('Error', 'Failed to load auto-roster');
+      router.back();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Members not yet in the auto-roster list
+  const availableMembers = useMemo(() => {
+    const listedUserIds = new Set(autoRoster.map((m) => m.userId));
+    return members.filter((m) => !listedUserIds.has(m.id));
+  }, [members, autoRoster]);
+
+  const showStoreErrorOr = (fallback: string) => {
+    const message = useOrganizationStore.getState().error || fallback;
+    Alert.alert('Error', message);
+  };
+
+  const handleAdd = async (member: OrganizationMember, position: Position) => {
+    if (!id || isProcessing) return;
+
+    setIsProcessing(true);
+    const success = await addAutoRosterMember(id, member.id, position);
+    setIsProcessing(false);
+
+    if (!success) {
+      showStoreErrorOr('Failed to add player to auto-roster');
+    }
+  };
+
+  const handleRemove = (userId: string, name: string) => {
+    if (!id) return;
+
+    Alert.alert(
+      'Remove from Auto-Roster',
+      `Remove ${name} from the auto-roster? They will no longer be automatically added to new events.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: async () => {
+            const success = await removeAutoRosterMember(id, userId);
+            if (!success) {
+              showStoreErrorOr('Failed to remove player from auto-roster');
+            }
+          },
+        },
+      ]
+    );
+  };
+
+  const handleMove = async (index: number, direction: -1 | 1) => {
+    if (!id || isProcessing) return;
+
+    const target = index + direction;
+    if (target < 0 || target >= autoRoster.length) return;
+
+    const orderedUserIds = autoRoster.map((m) => m.userId);
+    [orderedUserIds[index], orderedUserIds[target]] = [orderedUserIds[target], orderedUserIds[index]];
+
+    setIsProcessing(true);
+    const success = await reorderAutoRoster(id, orderedUserIds);
+    setIsProcessing(false);
+
+    if (!success) {
+      showStoreErrorOr('Failed to reorder auto-roster');
+    }
+  };
+
+  const positionButtons = (member: OrganizationMember) => {
+    const hasGoalie = !!member.positions?.goalie;
+    const hasSkater = !!member.positions?.skater;
+
+    // Organizer semantics: either position is allowed regardless of profile,
+    // but the member's own position(s) are emphasized as the default choice
+    return (
+      <View style={styles.positionButtons}>
+        <TouchableOpacity
+          style={[styles.positionButton, hasSkater && styles.positionButtonDefault]}
+          onPress={() => handleAdd(member, 'Skater')}
+          disabled={isProcessing}
+        >
+          <Text
+            style={[styles.positionButtonText, hasSkater && styles.positionButtonTextDefault]}
+            allowFontScaling={false}
+          >
+            Skater
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.positionButton, hasGoalie && styles.positionButtonDefault]}
+          onPress={() => handleAdd(member, 'Goalie')}
+          disabled={isProcessing}
+        >
+          <Text
+            style={[styles.positionButtonText, hasGoalie && styles.positionButtonTextDefault]}
+            allowFontScaling={false}
+          >
+            Goalie
+          </Text>
+        </TouchableOpacity>
+      </View>
+    );
+  };
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: 'Auto-Roster',
+          headerBackTitle: 'Back',
+          headerStyle: { backgroundColor: colors.bg.dark },
+          headerTintColor: colors.text.primary,
+        }}
+      />
+
+      {isLoading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.primary.teal} />
+        </View>
+      ) : (
+        <ScrollView style={styles.container}>
+          <View style={styles.explanationBox}>
+            <Text style={styles.explanationText}>
+              Auto-roster players are automatically added to new events for this organization, in
+              the order below. Skaters fill the roster first; extras go to the waitlist. Goalies
+              are always rostered.
+            </Text>
+          </View>
+
+          {autoRoster.length === 0 ? (
+            <View style={styles.emptyBox}>
+              <Text style={styles.emptyText}>No auto-roster players yet</Text>
+              <Text style={styles.emptyHint}>
+                Add your regulars so they're automatically rostered when you create an event.
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.list}>
+              {autoRoster.map((member, index) => (
+                <View key={member.userId} style={styles.memberRow}>
+                  <Text style={styles.orderNumber} allowFontScaling={false}>
+                    {index + 1}
+                  </Text>
+                  <View style={styles.memberInfo}>
+                    <Text style={styles.memberName} allowFontScaling={false}>
+                      {member.firstName} {member.lastName}
+                    </Text>
+                    <Text style={styles.memberPosition} allowFontScaling={false}>
+                      {member.position}
+                    </Text>
+                  </View>
+                  <View style={styles.rowActions}>
+                    <TouchableOpacity
+                      style={[styles.iconButton, index === 0 && styles.iconButtonDisabled]}
+                      onPress={() => handleMove(index, -1)}
+                      disabled={index === 0 || isProcessing}
+                    >
+                      <Ionicons
+                        name="chevron-up"
+                        size={20}
+                        color={index === 0 ? colors.text.placeholder : colors.text.secondary}
+                      />
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[
+                        styles.iconButton,
+                        index === autoRoster.length - 1 && styles.iconButtonDisabled,
+                      ]}
+                      onPress={() => handleMove(index, 1)}
+                      disabled={index === autoRoster.length - 1 || isProcessing}
+                    >
+                      <Ionicons
+                        name="chevron-down"
+                        size={20}
+                        color={
+                          index === autoRoster.length - 1
+                            ? colors.text.placeholder
+                            : colors.text.secondary
+                        }
+                      />
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.iconButton}
+                      onPress={() => handleRemove(member.userId, `${member.firstName} ${member.lastName}`)}
+                      disabled={isProcessing}
+                    >
+                      <Ionicons name="close" size={20} color={colors.status.error} />
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              ))}
+            </View>
+          )}
+
+          <TouchableOpacity style={styles.addButton} onPress={() => setShowAddModal(true)}>
+            <Ionicons name="add" size={20} color={colors.bg.darkest} />
+            <Text style={styles.addButtonText}>Add Player</Text>
+          </TouchableOpacity>
+
+          <View style={{ height: 40 }} />
+        </ScrollView>
+      )}
+
+      {/* Add Player Modal */}
+      <Modal visible={showAddModal} transparent animationType="slide">
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalContent}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>Add Player</Text>
+              <TouchableOpacity onPress={() => setShowAddModal(false)}>
+                <Text style={styles.modalDone}>Done</Text>
+              </TouchableOpacity>
+            </View>
+            <ScrollView style={styles.modalList}>
+              {availableMembers.length === 0 ? (
+                <Text style={styles.emptyText}>All members are already in the auto-roster</Text>
+              ) : (
+                availableMembers.map((member) => (
+                  <View key={member.id} style={styles.candidateRow}>
+                    <View style={styles.memberInfo}>
+                      <Text style={styles.memberName} allowFontScaling={false}>
+                        {member.firstName} {member.lastName}
+                      </Text>
+                      <Text style={styles.memberPosition} allowFontScaling={false}>
+                        {[
+                          member.positions?.skater ? `Skater (${member.positions.skater})` : null,
+                          member.positions?.goalie ? `Goalie (${member.positions.goalie})` : null,
+                        ]
+                          .filter(Boolean)
+                          .join(' · ') || 'No positions set'}
+                      </Text>
+                    </View>
+                    {positionButtons(member)}
+                  </View>
+                ))
+              )}
+              <View style={{ height: 20 }} />
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg.darkest,
+    padding: spacing.md,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.bg.darkest,
+  },
+  explanationBox: {
+    backgroundColor: colors.bg.dark,
+    padding: spacing.md,
+    borderRadius: radius.md,
+    marginBottom: spacing.lg,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+  },
+  explanationText: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    lineHeight: 20,
+  },
+  emptyBox: {
+    alignItems: 'center',
+    padding: spacing.lg,
+  },
+  emptyText: {
+    fontSize: 15,
+    color: colors.text.muted,
+    textAlign: 'center',
+  },
+  emptyHint: {
+    fontSize: 13,
+    color: colors.text.subtle,
+    textAlign: 'center',
+    marginTop: spacing.xs,
+  },
+  list: {
+    backgroundColor: colors.bg.dark,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+  },
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border.muted,
+  },
+  orderNumber: {
+    width: 24,
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.text.muted,
+  },
+  memberInfo: {
+    flex: 1,
+  },
+  memberName: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: colors.text.primary,
+  },
+  memberPosition: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: 2,
+  },
+  rowActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  iconButton: {
+    padding: spacing.sm,
+    borderRadius: radius.sm,
+    backgroundColor: colors.bg.elevated,
+  },
+  iconButtonDisabled: {
+    opacity: 0.5,
+  },
+  addButton: {
+    backgroundColor: colors.primary.teal,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.lg,
+  },
+  addButtonText: {
+    color: colors.bg.darkest,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  positionButtons: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+  },
+  positionButton: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.border.muted,
+    backgroundColor: colors.bg.elevated,
+  },
+  positionButtonDefault: {
+    borderColor: colors.primary.teal,
+    backgroundColor: colors.subtle.teal,
+  },
+  positionButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.muted,
+  },
+  positionButtonTextDefault: {
+    color: colors.primary.teal,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    backgroundColor: colors.bg.dark,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    paddingBottom: 34,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    borderBottomWidth: 0,
+    maxHeight: '70%',
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.default,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  modalDone: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.primary.teal,
+  },
+  modalList: {
+    padding: spacing.md,
+  },
+  candidateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.border.muted,
+  },
+});

--- a/apps/mobile/components/EventForm.tsx
+++ b/apps/mobile/components/EventForm.tsx
@@ -13,11 +13,13 @@ import {
   KeyboardAvoidingView,
   Keyboard,
   InputAccessoryView,
+  Switch,
 } from 'react-native';
 import { Picker } from '@react-native-picker/picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import type { EventVisibility, SkillLevel, EventDto, Organization } from '@bhmhockey/shared';
 import { SkillLevelSelector } from './SkillLevelSelector';
+import { useOrganizationStore } from '../stores/organizationStore';
 import { colors, spacing, radius } from '../theme';
 
 // Platform-specific Picker props for dark theme
@@ -40,6 +42,7 @@ export interface EventFormData {
   cost: number;
   visibility: EventVisibility;
   skillLevels?: SkillLevel[];
+  applyAutoRoster?: boolean;
 }
 
 interface EventFormProps {
@@ -72,6 +75,13 @@ export function EventForm({
   const [cost, setCost] = useState('');
   const [visibility, setVisibility] = useState<EventVisibility>('Public');
   const [skillLevels, setSkillLevels] = useState<SkillLevel[]>([]);
+  const [applyAutoRoster, setApplyAutoRoster] = useState(true);
+
+  // Auto-roster of the selected org (create mode only, admin-only endpoint)
+  const autoRoster = useOrganizationStore((state) => state.autoRoster);
+  const autoRosterOrgId = useOrganizationStore((state) => state.autoRosterOrgId);
+  const fetchAutoRoster = useOrganizationStore((state) => state.fetchAutoRoster);
+  const autoRosterCount = selectedOrgId && autoRosterOrgId === selectedOrgId ? autoRoster.length : 0;
 
   // Keyboard accessory ID for iOS
   const inputAccessoryViewID = 'eventFormAccessory';
@@ -198,6 +208,13 @@ export function EventForm({
     }
   }, [selectedOrgId, visibility]);
 
+  // Load the selected org's auto-roster so the toggle can show the player count
+  useEffect(() => {
+    if (mode === 'create' && selectedOrgId) {
+      fetchAutoRoster(selectedOrgId);
+    }
+  }, [mode, selectedOrgId, fetchAutoRoster]);
+
   // Helper to check if org can be shown in visibility picker
   const hasOrganization = mode === 'edit'
     ? !!initialData?.organizationId
@@ -307,6 +324,7 @@ export function EventForm({
       cost: parseFloat(cost),
       visibility,
       skillLevels: skillLevels.length > 0 ? skillLevels : undefined,
+      applyAutoRoster: selectedOrgId ? applyAutoRoster : undefined,
     };
 
     await onSubmit(formData);
@@ -506,6 +524,26 @@ export function EventForm({
         </View>
 
 
+        {/* Auto-Roster Toggle (create mode, org events with a non-empty auto-roster) */}
+        {mode === 'create' && !!selectedOrgId && autoRosterCount > 0 && (
+          <View style={styles.field}>
+            <View style={styles.switchRow}>
+              <Text style={styles.switchLabel} allowFontScaling={false}>
+                Add auto-roster ({autoRosterCount} {autoRosterCount === 1 ? 'player' : 'players'})
+              </Text>
+              <Switch
+                value={applyAutoRoster}
+                onValueChange={setApplyAutoRoster}
+                trackColor={{ false: colors.bg.hover, true: colors.primary.teal }}
+                thumbColor={applyAutoRoster ? colors.text.primary : colors.text.muted}
+              />
+            </View>
+            <Text style={styles.skillNote}>
+              Your organization's regulars will be placed on the roster automatically
+            </Text>
+          </View>
+        )}
+
         {/* Skill Levels */}
         <View style={styles.field}>
           <SkillLevelSelector
@@ -687,6 +725,22 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: colors.text.muted,
     marginTop: spacing.xs,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: colors.bg.elevated,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+  },
+  switchLabel: {
+    fontSize: 15,
+    color: colors.text.primary,
+    flex: 1,
+    marginRight: spacing.sm,
   },
   submitButton: {
     backgroundColor: colors.primary.teal,

--- a/apps/mobile/stores/organizationStore.ts
+++ b/apps/mobile/stores/organizationStore.ts
@@ -1,11 +1,22 @@
 import { create } from 'zustand';
 import { organizationService } from '@bhmhockey/api-client';
-import type { Organization, OrganizationSubscription, CreateOrganizationRequest } from '@bhmhockey/shared';
+import type { Organization, OrganizationSubscription, CreateOrganizationRequest, OrganizationMember, AutoRosterMember, Position } from '@bhmhockey/shared';
+
+/** Extract message from ApiError objects or Error instances */
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string') {
+    return (error as any).message || fallback;
+  }
+  return fallback;
+}
 
 interface OrganizationState {
   organizations: Organization[];
   mySubscriptions: OrganizationSubscription[];
   myOrganizations: Organization[]; // Organizations I created/own
+  members: OrganizationMember[]; // Members of the org being viewed (admin flows)
+  autoRoster: AutoRosterMember[]; // Auto-roster of the org being viewed (admin only)
+  autoRosterOrgId: string | null; // Which org the loaded autoRoster belongs to
   isLoading: boolean;
   error: string | null;
 
@@ -18,12 +29,24 @@ interface OrganizationState {
   unsubscribe: (organizationId: string) => Promise<void>;
   deleteOrganization: (organizationId: string) => Promise<boolean>;
   clearError: () => void;
+
+  // Members (admin flows)
+  fetchMembers: (organizationId: string) => Promise<void>;
+
+  // Auto-roster actions (admin only)
+  fetchAutoRoster: (organizationId: string) => Promise<void>;
+  addAutoRosterMember: (organizationId: string, userId: string, position: Position) => Promise<boolean>;
+  removeAutoRosterMember: (organizationId: string, userId: string) => Promise<boolean>;
+  reorderAutoRoster: (organizationId: string, orderedUserIds: string[]) => Promise<boolean>;
 }
 
 export const useOrganizationStore = create<OrganizationState>((set, get) => ({
   organizations: [],
   mySubscriptions: [],
   myOrganizations: [],
+  members: [],
+  autoRoster: [],
+  autoRosterOrgId: null,
   isLoading: false,
   error: null,
 
@@ -154,4 +177,79 @@ export const useOrganizationStore = create<OrganizationState>((set, get) => ({
   },
 
   clearError: () => set({ error: null }),
+
+  fetchMembers: async (organizationId: string) => {
+    try {
+      const members = await organizationService.getMembers(organizationId);
+      set({ members });
+    } catch (error) {
+      set({ error: getErrorMessage(error, 'Failed to load members') });
+    }
+  },
+
+  fetchAutoRoster: async (organizationId: string) => {
+    try {
+      const autoRoster = await organizationService.getAutoRoster(organizationId);
+      set({ autoRoster, autoRosterOrgId: organizationId });
+    } catch (error) {
+      set({ error: getErrorMessage(error, 'Failed to load auto-roster') });
+    }
+  },
+
+  addAutoRosterMember: async (organizationId: string, userId: string, position: Position) => {
+    try {
+      const member = await organizationService.addAutoRosterMember(organizationId, { userId, position });
+      set((state) => ({ autoRoster: [...state.autoRoster, member], autoRosterOrgId: organizationId }));
+      return true;
+    } catch (error) {
+      set({ error: getErrorMessage(error, 'Failed to add player to auto-roster') });
+      return false;
+    }
+  },
+
+  removeAutoRosterMember: async (organizationId: string, userId: string) => {
+    const { autoRoster } = get();
+
+    // Optimistic update
+    set({ autoRoster: autoRoster.filter((m) => m.userId !== userId) });
+
+    try {
+      await organizationService.removeAutoRosterMember(organizationId, userId);
+      return true;
+    } catch (error) {
+      // Rollback on failure
+      set({
+        autoRoster,
+        error: getErrorMessage(error, 'Failed to remove player from auto-roster'),
+      });
+      return false;
+    }
+  },
+
+  reorderAutoRoster: async (organizationId: string, orderedUserIds: string[]) => {
+    const { autoRoster } = get();
+
+    // Optimistic update - reorder locally
+    const byUserId = new Map(autoRoster.map((m) => [m.userId, m]));
+    const reordered = orderedUserIds
+      .map((userId, index) => {
+        const member = byUserId.get(userId);
+        return member ? { ...member, sortOrder: index } : null;
+      })
+      .filter((m): m is AutoRosterMember => m !== null);
+    set({ autoRoster: reordered });
+
+    try {
+      const updated = await organizationService.reorderAutoRoster(organizationId, orderedUserIds);
+      set({ autoRoster: updated });
+      return true;
+    } catch (error) {
+      // Rollback on failure
+      set({
+        autoRoster,
+        error: getErrorMessage(error, 'Failed to reorder auto-roster'),
+      });
+      return false;
+    }
+  },
 }));

--- a/packages/api-client/__tests__/services/organizations.test.ts
+++ b/packages/api-client/__tests__/services/organizations.test.ts
@@ -1,0 +1,104 @@
+/**
+ * OrganizationService Tests - Verifying the API client calls the correct
+ * auto-roster endpoints with the correct payloads.
+ */
+
+// Mock AsyncStorage before any imports
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+// Store axios mock functions
+const mockPost = jest.fn();
+const mockGet = jest.fn();
+const mockPut = jest.fn();
+const mockDelete = jest.fn();
+
+// Mock axios
+jest.mock('axios', () => ({
+  create: jest.fn(() => ({
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+    post: mockPost,
+    get: mockGet,
+    put: mockPut,
+    delete: mockDelete,
+  })),
+}));
+
+// Import after mocking
+import { organizationService } from '../../src/services/organizations';
+import { initializeApiClient } from '../../src/client';
+
+const mockMember = {
+  id: 'member-1',
+  userId: 'user-1',
+  firstName: 'Test',
+  lastName: 'User',
+  positions: { skater: 'Silver' },
+  position: 'Skater',
+  sortOrder: 0,
+  addedAt: '2026-07-16T00:00:00Z',
+};
+
+describe('organizationService auto-roster', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    initializeApiClient({ baseURL: 'http://localhost:5001/api' });
+  });
+
+  describe('getAutoRoster', () => {
+    it('fetches the auto-roster from the correct endpoint', async () => {
+      mockGet.mockResolvedValueOnce({ data: [mockMember] });
+
+      const result = await organizationService.getAutoRoster('org-1');
+
+      expect(mockGet).toHaveBeenCalledWith('/organizations/org-1/auto-roster');
+      expect(result).toEqual([mockMember]);
+    });
+  });
+
+  describe('addAutoRosterMember', () => {
+    it('posts the user and position to the correct endpoint', async () => {
+      mockPost.mockResolvedValueOnce({ data: mockMember });
+
+      const result = await organizationService.addAutoRosterMember('org-1', {
+        userId: 'user-1',
+        position: 'Skater',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith('/organizations/org-1/auto-roster', {
+        userId: 'user-1',
+        position: 'Skater',
+      });
+      expect(result).toEqual(mockMember);
+    });
+  });
+
+  describe('removeAutoRosterMember', () => {
+    it('deletes the member by user id', async () => {
+      mockDelete.mockResolvedValueOnce({});
+
+      await organizationService.removeAutoRosterMember('org-1', 'user-1');
+
+      expect(mockDelete).toHaveBeenCalledWith('/organizations/org-1/auto-roster/user-1');
+    });
+  });
+
+  describe('reorderAutoRoster', () => {
+    it('puts the ordered user ids to the order endpoint', async () => {
+      mockPut.mockResolvedValueOnce({ data: [mockMember] });
+
+      const result = await organizationService.reorderAutoRoster('org-1', ['user-2', 'user-1']);
+
+      expect(mockPut).toHaveBeenCalledWith('/organizations/org-1/auto-roster/order', {
+        orderedUserIds: ['user-2', 'user-1'],
+      });
+      expect(result).toEqual([mockMember]);
+    });
+  });
+});

--- a/packages/api-client/src/services/organizations.ts
+++ b/packages/api-client/src/services/organizations.ts
@@ -5,7 +5,9 @@ import type {
   OrganizationAdmin,
   CreateOrganizationRequest,
   UpdateOrganizationRequest,
-  AddAdminRequest
+  AddAdminRequest,
+  AutoRosterMember,
+  AddAutoRosterMemberRequest
 } from '@bhmhockey/shared';
 import { apiClient } from '../client';
 
@@ -119,5 +121,42 @@ export const organizationService = {
    */
   async removeAdmin(organizationId: string, userId: string): Promise<void> {
     await apiClient.instance.delete(`/organizations/${organizationId}/admins/${userId}`);
+  },
+
+  // Auto-roster methods (admin only) - org "regulars" auto-added to new org events
+
+  /**
+   * Get the organization's auto-roster list ordered by sort order (admin only)
+   */
+  async getAutoRoster(organizationId: string): Promise<AutoRosterMember[]> {
+    const response = await apiClient.instance.get<AutoRosterMember[]>(`/organizations/${organizationId}/auto-roster`);
+    return response.data;
+  },
+
+  /**
+   * Add a subscriber to the organization's auto-roster (admin only)
+   */
+  async addAutoRosterMember(organizationId: string, data: AddAutoRosterMemberRequest): Promise<AutoRosterMember> {
+    const response = await apiClient.instance.post<AutoRosterMember>(`/organizations/${organizationId}/auto-roster`, data);
+    return response.data;
+  },
+
+  /**
+   * Remove a user from the organization's auto-roster (admin only)
+   */
+  async removeAutoRosterMember(organizationId: string, userId: string): Promise<void> {
+    await apiClient.instance.delete(`/organizations/${organizationId}/auto-roster/${userId}`);
+  },
+
+  /**
+   * Reorder the organization's auto-roster (admin only).
+   * All current members must be included exactly once.
+   */
+  async reorderAutoRoster(organizationId: string, orderedUserIds: string[]): Promise<AutoRosterMember[]> {
+    const response = await apiClient.instance.put<AutoRosterMember[]>(
+      `/organizations/${organizationId}/auto-roster/order`,
+      { orderedUserIds }
+    );
+    return response.data;
   },
 };

--- a/packages/shared/src/__tests__/index-exports.test.ts
+++ b/packages/shared/src/__tests__/index-exports.test.ts
@@ -5,6 +5,10 @@ import {
   AddTournamentAdminRequest,
   UpdateTournamentAdminRoleRequest,
   TransferOwnershipRequest,
+  AutoRosterMember,
+  AddAutoRosterMemberRequest,
+  ReorderAutoRosterRequest,
+  CreateEventRequest,
 } from '../index';
 
 describe('Tournament Admin Type Exports', () => {
@@ -49,5 +53,47 @@ describe('Tournament Admin Type Exports', () => {
   it('should export TournamentAdminRole from main index', () => {
     const role: TournamentAdminRole = 'Owner';
     expect(role).toBe('Owner');
+  });
+});
+
+describe('Auto-Roster Type Exports', () => {
+  it('should export AutoRosterMember from main index', () => {
+    const member: AutoRosterMember = {
+      id: 'member-123',
+      userId: 'user-456',
+      firstName: 'John',
+      lastName: 'Doe',
+      positions: { skater: 'Silver' },
+      position: 'Skater',
+      sortOrder: 0,
+      addedAt: '2026-07-16T00:00:00Z',
+    };
+    expect(member).toBeDefined();
+  });
+
+  it('should export AddAutoRosterMemberRequest from main index', () => {
+    const request: AddAutoRosterMemberRequest = {
+      userId: 'user-123',
+      position: 'Goalie',
+    };
+    expect(request).toBeDefined();
+  });
+
+  it('should export ReorderAutoRosterRequest from main index', () => {
+    const request: ReorderAutoRosterRequest = {
+      orderedUserIds: ['user-1', 'user-2'],
+    };
+    expect(request).toBeDefined();
+  });
+
+  it('should accept applyAutoRoster on CreateEventRequest', () => {
+    const request: CreateEventRequest = {
+      eventDate: '2026-07-23T00:00:00Z',
+      maxPlayers: 12,
+      cost: 0,
+      organizationId: 'org-1',
+      applyAutoRoster: false,
+    };
+    expect(request.applyAutoRoster).toBe(false);
   });
 });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -91,6 +91,27 @@ export interface OrganizationMember {
 
 export type SkillLevel = 'Gold' | 'Silver' | 'Bronze' | 'D-League';
 
+// Auto-roster types - org "regulars" auto-added to new org events
+export interface AutoRosterMember {
+  id: string;
+  userId: string;
+  firstName: string;
+  lastName: string;
+  positions?: UserPositions;  // User's profile positions
+  position: Position;         // Position they'll be auto-added as
+  sortOrder: number;
+  addedAt: string;
+}
+
+export interface AddAutoRosterMemberRequest {
+  userId: string;
+  position: Position;
+}
+
+export interface ReorderAutoRosterRequest {
+  orderedUserIds: string[];   // All auto-roster member user IDs in the new order
+}
+
 export interface OrganizationSubscription {
   id: string;
   organization: Organization;
@@ -254,6 +275,7 @@ export interface CreateEventRequest {
   registrationDeadline?: string;
   visibility?: EventVisibility;  // Default: 'Public'
   skillLevels?: SkillLevel[];    // Optional - overrides org's skill levels if set
+  applyAutoRoster?: boolean;     // Auto-add the org's auto-roster members (default true; ignored for standalone events)
 }
 
 export interface UpdateEventRequest {


### PR DESCRIPTION
## Summary

Org admins can now maintain an ordered "auto-roster" list of regulars per organization. When an org event is created, listed players are automatically placed on the roster server-side — atomically, before the "New Game" notification goes out — eliminating the race between manually adding regulars and public signups.

## Behavior

- New `OrganizationAutoRosterMembers` table (org, user, position, sort order; unique per org+user). Additive-only migration.
- Four admin-only endpoints (list/add/remove/reorder) under `/api/organizations/{id}/auto-roster`, all authorized via `OrganizationAdminService.IsUserAdminAsync`. Add requires current org membership.
- `CreateEventRequest.ApplyAutoRoster` (default `true`): on org-event creation, list members are added in order — goalies always roster (exempt from MaxPlayers per existing capacity rules), skaters roster until capacity then overflow to the waitlist in list order. Paid events place regulars directly on the roster with `PaymentStatus=Pending` (mirrors manual organizer adds; self-registration still waitlists first — unchanged). No `PaymentDeadlineAt`.
- Cancellation and waitlist-promotion logic intentionally untouched.
- Mobile: Auto-Roster management screen in org settings (member picker, per-member position, reorder, remove) and a default-ON toggle on the create-event form.
- DTOs mirrored in `@bhmhockey/shared` and `@bhmhockey/api-client` per repo convention. No `UserDto` changes. No migration drops.

## Testing

- API suite: 896 → 931 (+35: service validation/auth, controller, and CreateAsync behaviors: goalie exemption, overflow ordering, paid=Pending, toggle off, unsubscribed/inactive skip, duplicate skip, notification gating)
- Frontend suites: 136 → 152; mobile type-check clean
- Live end-to-end verified via curl against a throwaway org (paid placement, overflow order, toggle-off, unsubscribed skip, non-admin 401/403, duplicate/non-member 400s), then cleaned up
- Manually tested in the iOS simulator by @auc0le (list management, event creation fill, overflow, paid flow, toggle off)

Note: `yarn lint` fails on main as well (missing `eslint-config-prettier`, lint is not part of CI) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)