### PR TITLE
Add GroupMe chat links to organizations and events with live fallback

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Controllers/EventsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/EventsControllerTests.cs
@@ -245,6 +245,27 @@ public class EventsControllerTests
         returnedEvent.Should().NotBeNull();
     }
 
+    [Fact]
+    public async Task Create_WhenServiceThrowsInvalidOperation_ReturnsBadRequest()
+    {
+        // Arrange - e.g. invalid GroupMe link or invalid visibility config
+        SetupAuthenticatedUser();
+        var request = new CreateEventRequest(
+            EventDate: DateTime.UtcNow.AddDays(7),
+            MaxPlayers: 10,
+            Cost: 0,
+            GroupMeLink: "https://discord.gg/abc"
+        );
+        _mockEventService.Setup(s => s.CreateAsync(request, _testUserId))
+            .ThrowsAsync(new InvalidOperationException("GroupMe link must be an https://groupme.com URL (e.g., https://groupme.com/join_group/...)."));
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
     #endregion
 
     #region Update Tests
@@ -294,6 +315,22 @@ public class EventsControllerTests
 
         // Assert
         result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Update_WhenServiceThrowsInvalidOperation_ReturnsBadRequest()
+    {
+        // Arrange - e.g. invalid GroupMe link
+        SetupAuthenticatedUser();
+        var request = new UpdateEventRequest(null, null, null, null, null, null, null, null, null, null, null, null, GroupMeLink: "http://groupme.com/join_group/abc");
+        _mockEventService.Setup(s => s.UpdateAsync(_testEventId, request, _testUserId))
+            .ThrowsAsync(new InvalidOperationException("GroupMe link must be an https://groupme.com URL (e.g., https://groupme.com/join_group/...)."));
+
+        // Act
+        var result = await _controller.Update(_testEventId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
@@ -135,6 +135,22 @@ public class OrganizationsControllerTests
         createdResult!.Value.Should().BeEquivalentTo(createdOrg);
     }
 
+    [Fact]
+    public async Task Create_WhenServiceThrowsInvalidOperation_ReturnsBadRequest()
+    {
+        // Arrange - e.g. invalid GroupMe link or duplicate name
+        SetupAuthenticatedUser(_testUserId);
+        var request = new CreateOrganizationRequest("New Org", null, null, null, null, null, null, null, null, null, null, "https://discord.gg/abc");
+        _mockOrgService.Setup(s => s.CreateAsync(request, _testUserId))
+            .ThrowsAsync(new InvalidOperationException("GroupMe link must be an https://groupme.com URL (e.g., https://groupme.com/join_group/...)."));
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
     #endregion
 
     #region Update Tests
@@ -170,6 +186,23 @@ public class OrganizationsControllerTests
 
         // Assert
         result.Result.Should().BeOfType<NotFoundResult>();
+    }
+
+    [Fact]
+    public async Task Update_WhenServiceThrowsInvalidOperation_ReturnsBadRequest()
+    {
+        // Arrange - e.g. invalid GroupMe link
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var request = new UpdateOrganizationRequest(null, null, null, null, null, null, null, null, null, null, null, "http://groupme.com/join_group/abc");
+        _mockOrgService.Setup(s => s.UpdateAsync(orgId, request, _testUserId))
+            .ThrowsAsync(new InvalidOperationException("GroupMe link must be an https://groupme.com URL (e.g., https://groupme.com/join_group/...)."));
+
+        // Act
+        var result = await _controller.Update(orgId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<BadRequestObjectResult>();
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -75,7 +75,7 @@ public class EventServiceTests : IDisposable
         return user;
     }
 
-    private async Task<Organization> CreateTestOrganization(Guid creatorId, string name = "Test Org")
+    private async Task<Organization> CreateTestOrganization(Guid creatorId, string name = "Test Org", string? groupMeLink = null)
     {
         var org = new Organization
         {
@@ -83,7 +83,8 @@ public class EventServiceTests : IDisposable
             Name = name,
             CreatorId = creatorId,
             IsActive = true,
-            CreatedAt = DateTime.UtcNow
+            CreatedAt = DateTime.UtcNow,
+            GroupMeLink = groupMeLink
         };
 
         _context.Organizations.Add(org);
@@ -128,10 +129,12 @@ public class EventServiceTests : IDisposable
         string status = "Published",
         DateTime? eventDate = null,
         decimal cost = 25.00m,
-        bool isRosterPublished = false)
+        bool isRosterPublished = false,
+        string? groupMeLink = null)
     {
         var evt = new Event
         {
+            GroupMeLink = groupMeLink,
             Id = Guid.NewGuid(),
             CreatorId = creatorId,
             OrganizationId = organizationId,
@@ -3508,6 +3511,251 @@ public class EventServiceTests : IDisposable
         // Assert
         result.Status.Should().Be("Registered");
         result.User!.IsGhostPlayer.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region GroupMe Link Tests
+
+    private static UpdateEventRequest GroupMeLinkUpdateRequest(string? groupMeLink)
+    {
+        return new UpdateEventRequest(
+            Name: null,
+            Description: null,
+            EventDate: null,
+            Duration: null,
+            Venue: null,
+            MaxPlayers: null,
+            Cost: null,
+            RegistrationDeadline: null,
+            Status: null,
+            Visibility: null,
+            SkillLevels: null,
+            SlotPositionLabels: null,
+            GroupMeLink: groupMeLink
+        );
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_EventWithOwnLink_OverridesOrgLink()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id, groupMeLink: "https://groupme.com/join_group/org");
+        var evt = await CreateTestEvent(creator.Id, organizationId: org.Id, groupMeLink: "https://groupme.com/join_group/event");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/event");
+        result.GroupMeLinkSource.Should().Be("event");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_OrgEventWithoutOwnLink_FallsBackToOrgLink()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id, groupMeLink: "https://groupme.com/join_group/org");
+        var evt = await CreateTestEvent(creator.Id, organizationId: org.Id);
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/org");
+        result.GroupMeLinkSource.Should().Be("organization");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_OrgEventWithNoLinks_ReturnsNullLinkAndSource()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+        var evt = await CreateTestEvent(creator.Id, organizationId: org.Id);
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().BeNull();
+        result.GroupMeLinkSource.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_StandaloneEventWithLink_ReturnsEventSource()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var evt = await CreateTestEvent(creator.Id, groupMeLink: "https://groupme.com/join_group/solo");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/solo");
+        result.GroupMeLinkSource.Should().Be("event");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_StandaloneEventWithoutLink_ReturnsNull()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var evt = await CreateTestEvent(creator.Id);
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().BeNull();
+        result.GroupMeLinkSource.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_OrgLinkRotated_InheritingEventReflectsNewLinkImmediately()
+    {
+        // Arrange - live fallback: link resolves at read time, not copied at creation
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id, groupMeLink: "https://groupme.com/join_group/old");
+        var evt = await CreateTestEvent(creator.Id, organizationId: org.Id);
+
+        var before = await _sut.GetByIdAsync(evt.Id, creator.Id);
+        before!.GroupMeLink.Should().Be("https://groupme.com/join_group/old");
+
+        org.GroupMeLink = "https://groupme.com/join_group/new";
+        await _context.SaveChangesAsync();
+
+        // Act
+        var after = await _sut.GetByIdAsync(evt.Id, creator.Id);
+
+        // Assert
+        after!.GroupMeLink.Should().Be("https://groupme.com/join_group/new");
+        after.GroupMeLinkSource.Should().Be("organization");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithWhitespacePaddedLink_TrimsAndStores()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateEventRequest(
+            EventDate: DateTime.UtcNow.AddDays(7),
+            MaxPlayers: 10,
+            Cost: 0,
+            GroupMeLink: "  https://groupme.com/join_group/abc  ");
+
+        // Act
+        var result = await _sut.CreateAsync(request, creator.Id);
+
+        // Assert
+        result.GroupMeLink.Should().Be("https://groupme.com/join_group/abc");
+        result.GroupMeLinkSource.Should().Be("event");
+        var evt = await _context.Events.FindAsync(result.Id);
+        evt!.GroupMeLink.Should().Be("https://groupme.com/join_group/abc");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithEmptyLink_StoresNull()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateEventRequest(
+            EventDate: DateTime.UtcNow.AddDays(7),
+            MaxPlayers: 10,
+            Cost: 0,
+            GroupMeLink: "   ");
+
+        // Act
+        var result = await _sut.CreateAsync(request, creator.Id);
+
+        // Assert
+        var evt = await _context.Events.FindAsync(result.Id);
+        evt!.GroupMeLink.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("http://groupme.com/join_group/abc")]
+    [InlineData("https://discord.gg/abc")]
+    [InlineData("not a url")]
+    public async Task CreateAsync_WithInvalidGroupMeLink_ThrowsInvalidOperationException(string link)
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateEventRequest(
+            EventDate: DateTime.UtcNow.AddDays(7),
+            MaxPlayers: 10,
+            Cost: 0,
+            GroupMeLink: link);
+
+        // Act & Assert
+        await _sut.Invoking(s => s.CreateAsync(request, creator.Id))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*GroupMe link*");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetGroupMeLink_OverridesOrgLink()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id, groupMeLink: "https://groupme.com/join_group/org");
+        var evt = await CreateTestEvent(creator.Id, organizationId: org.Id);
+
+        // Act
+        var result = await _sut.UpdateAsync(evt.Id, GroupMeLinkUpdateRequest("https://groupme.com/join_group/override"), creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/override");
+        result.GroupMeLinkSource.Should().Be("event");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ClearGroupMeLinkWithEmptyString_FallsBackToOrgLink()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id, groupMeLink: "https://groupme.com/join_group/org");
+        var evt = await CreateTestEvent(creator.Id, organizationId: org.Id, groupMeLink: "https://groupme.com/join_group/event");
+
+        // Act
+        var result = await _sut.UpdateAsync(evt.Id, GroupMeLinkUpdateRequest(""), creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/org");
+        result.GroupMeLinkSource.Should().Be("organization");
+        var updated = await _context.Events.FindAsync(evt.Id);
+        updated!.GroupMeLink.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NullGroupMeLink_LeavesLinkUnchanged()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var evt = await CreateTestEvent(creator.Id, groupMeLink: "https://groupme.com/join_group/keep");
+
+        // Act
+        var result = await _sut.UpdateAsync(evt.Id, GroupMeLinkUpdateRequest(null), creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/keep");
+        result.GroupMeLinkSource.Should().Be("event");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithInvalidGroupMeLink_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var evt = await CreateTestEvent(creator.Id);
+
+        // Act & Assert
+        await _sut.Invoking(s => s.UpdateAsync(evt.Id, GroupMeLinkUpdateRequest("https://discord.gg/abc"), creator.Id))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*GroupMe link*");
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -766,4 +766,173 @@ public class OrganizationServiceTests : IDisposable
     }
 
     #endregion
+
+    #region GroupMe Link Tests
+
+    private static UpdateOrganizationRequest GroupMeLinkUpdateRequest(string? groupMeLink)
+    {
+        return new UpdateOrganizationRequest(
+            Name: null,
+            Description: null,
+            Location: null,
+            SkillLevels: null,
+            DefaultDayOfWeek: null,
+            DefaultStartTime: null,
+            DefaultDurationMinutes: null,
+            DefaultMaxPlayers: null,
+            DefaultCost: null,
+            DefaultVenue: null,
+            DefaultVisibility: null,
+            GroupMeLink: groupMeLink
+        );
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithWhitespacePaddedGroupMeLink_TrimsAndStores()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateOrganizationRequest(
+            Name: "GroupMe Org",
+            Description: null,
+            Location: null,
+            SkillLevels: null,
+            DefaultDayOfWeek: null,
+            DefaultStartTime: null,
+            DefaultDurationMinutes: null,
+            DefaultMaxPlayers: null,
+            DefaultCost: null,
+            DefaultVenue: null,
+            DefaultVisibility: null,
+            GroupMeLink: "  https://groupme.com/join_group/abc  ");
+
+        // Act
+        var result = await _sut.CreateAsync(request, creator.Id);
+
+        // Assert
+        result.GroupMeLink.Should().Be("https://groupme.com/join_group/abc");
+        var org = await _context.Organizations.FindAsync(result.Id);
+        org!.GroupMeLink.Should().Be("https://groupme.com/join_group/abc");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithInvalidGroupMeLink_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateOrganizationRequest(
+            Name: "Bad Link Org",
+            Description: null,
+            Location: null,
+            SkillLevels: null,
+            DefaultDayOfWeek: null,
+            DefaultStartTime: null,
+            DefaultDurationMinutes: null,
+            DefaultMaxPlayers: null,
+            DefaultCost: null,
+            DefaultVenue: null,
+            DefaultVisibility: null,
+            GroupMeLink: "http://groupme.com/join_group/abc");
+
+        // Act & Assert
+        await _sut.Invoking(s => s.CreateAsync(request, creator.Id))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*GroupMe link*");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetGroupMeLink_ReturnsLinkInDto()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+
+        // Act
+        var result = await _sut.UpdateAsync(org.Id, GroupMeLinkUpdateRequest("https://www.groupme.com/join_group/xyz"), creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://www.groupme.com/join_group/xyz");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_EmptyGroupMeLink_ClearsLink()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+        org.GroupMeLink = "https://groupme.com/join_group/old";
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.UpdateAsync(org.Id, GroupMeLinkUpdateRequest(""), creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().BeNull();
+        var updated = await _context.Organizations.FindAsync(org.Id);
+        updated!.GroupMeLink.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NullGroupMeLink_LeavesLinkUnchanged()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+        org.GroupMeLink = "https://groupme.com/join_group/keep";
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.UpdateAsync(org.Id, GroupMeLinkUpdateRequest(null), creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/keep");
+    }
+
+    [Theory]
+    [InlineData("http://groupme.com/join_group/abc")]  // not https
+    [InlineData("https://discord.gg/abc")]             // wrong host
+    [InlineData("groupme.com/join_group/abc")]         // not absolute https URL
+    public async Task UpdateAsync_WithInvalidGroupMeLink_ThrowsInvalidOperationException(string link)
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+
+        // Act & Assert
+        await _sut.Invoking(s => s.UpdateAsync(org.Id, GroupMeLinkUpdateRequest(link), creator.Id))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*GroupMe link*");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_GroupMeLinkOverMaxLength_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+        var longLink = "https://groupme.com/join_group/" + new string('a', 500);
+
+        // Act & Assert
+        await _sut.Invoking(s => s.UpdateAsync(org.Id, GroupMeLinkUpdateRequest(longLink), creator.Id))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*500*");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsGroupMeLink()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+        org.GroupMeLink = "https://groupme.com/join_group/visible";
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByIdAsync(org.Id, creator.Id);
+
+        // Assert
+        result!.GroupMeLink.Should().Be("https://groupme.com/join_group/visible");
+    }
+
+    #endregion
 }

--- a/apps/api/BHMHockey.Api/Controllers/EventsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/EventsController.cs
@@ -111,9 +111,16 @@ public class EventsController : ControllerBase
         }
 
         var userId = GetCurrentUserId();
-        var eventDto = await _eventService.CreateAsync(request, userId);
-
-        return CreatedAtAction(nameof(GetById), new { id = eventDto.Id }, eventDto);
+        try
+        {
+            var eventDto = await _eventService.CreateAsync(request, userId);
+            return CreatedAtAction(nameof(GetById), new { id = eventDto.Id }, eventDto);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Event creation rejected for user {UserId}: {Message}", userId, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     /// <summary>
@@ -124,14 +131,22 @@ public class EventsController : ControllerBase
     public async Task<ActionResult<EventDto>> Update(Guid id, [FromBody] UpdateEventRequest request)
     {
         var userId = GetCurrentUserId();
-        var eventDto = await _eventService.UpdateAsync(id, request, userId);
-
-        if (eventDto == null)
+        try
         {
-            return NotFound();
-        }
+            var eventDto = await _eventService.UpdateAsync(id, request, userId);
 
-        return Ok(eventDto);
+            if (eventDto == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(eventDto);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Event update rejected for event {EventId}: {Message}", id, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     /// <summary>

--- a/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
@@ -101,8 +101,16 @@ public class OrganizationsController : ControllerBase
         }
 
         var userId = GetCurrentUserId();
-        var organization = await _organizationService.CreateAsync(request, userId);
-        return CreatedAtAction(nameof(GetById), new { id = organization.Id }, organization);
+        try
+        {
+            var organization = await _organizationService.CreateAsync(request, userId);
+            return CreatedAtAction(nameof(GetById), new { id = organization.Id }, organization);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Organization creation rejected for user {UserId}: {Message}", userId, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     /// <summary>
@@ -113,14 +121,22 @@ public class OrganizationsController : ControllerBase
     public async Task<ActionResult<OrganizationDto>> Update(Guid id, [FromBody] UpdateOrganizationRequest request)
     {
         var userId = GetCurrentUserId();
-        var organization = await _organizationService.UpdateAsync(id, request, userId);
-
-        if (organization == null)
+        try
         {
-            return NotFound();
-        }
+            var organization = await _organizationService.UpdateAsync(id, request, userId);
 
-        return Ok(organization);
+            if (organization == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(organization);
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Organization update rejected for organization {OrganizationId}: {Message}", id, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     /// <summary>

--- a/apps/api/BHMHockey.Api/Migrations/20260717035151_AddGroupMeLinks.Designer.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717035151_AddGroupMeLinks.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BHMHockey.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHMHockey.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717035151_AddGroupMeLinks")]
+    partial class AddGroupMeLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/BHMHockey.Api/Migrations/20260717035151_AddGroupMeLinks.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717035151_AddGroupMeLinks.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHMHockey.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGroupMeLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "GroupMeLink",
+                table: "Organizations",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GroupMeLink",
+                table: "Events",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GroupMeLink",
+                table: "Organizations");
+
+            migrationBuilder.DropColumn(
+                name: "GroupMeLink",
+                table: "Events");
+        }
+    }
+}

--- a/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
@@ -35,7 +35,10 @@ public record EventDto(
     DateTime? MyPaymentDeadline,  // Current user's payment deadline after promotion (null if none)
     bool AmIWaitlisted,           // Convenience flag - true if current user is on waitlist
     // Slot position labels (organizer feature)
-    Dictionary<int, string>? SlotPositionLabels  // Maps slot index to position label (e.g., {1: "C", 2: "LW"})
+    Dictionary<int, string>? SlotPositionLabels,  // Maps slot index to position label (e.g., {1: "C", 2: "LW"})
+    // GroupMe chat link, resolved at read time: event override wins, else org's link
+    string? GroupMeLink = null,
+    string? GroupMeLinkSource = null  // "event" | "organization" | null - where the resolved link came from
 );
 
 public record CreateEventRequest(
@@ -50,7 +53,8 @@ public record CreateEventRequest(
     DateTime? RegistrationDeadline = null,
     string? Visibility = "Public",       // Default to public if not specified
     List<string>? SkillLevels = null,    // Optional - overrides org's skill levels if set
-    bool ApplyAutoRoster = true          // Auto-add the org's auto-roster members (ignored for standalone events)
+    bool ApplyAutoRoster = true,         // Auto-add the org's auto-roster members (ignored for standalone events)
+    string? GroupMeLink = null           // Optional game-specific GroupMe link (blank inherits org's link)
 );
 
 public record UpdateEventRequest(
@@ -65,7 +69,8 @@ public record UpdateEventRequest(
     string? Status,
     string? Visibility,                            // Can change visibility after creation
     List<string>? SkillLevels,                     // Can change skill levels after creation
-    Dictionary<int, string>? SlotPositionLabels   // Slot position labels (e.g., {1: "C", 2: "LW"})
+    Dictionary<int, string>? SlotPositionLabels,  // Slot position labels (e.g., {1: "C", 2: "LW"})
+    string? GroupMeLink = null                    // Empty/whitespace clears the override (falls back to org); null leaves unchanged
 );
 
 public record EventRegistrationDto(

--- a/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
@@ -17,7 +17,8 @@ public record OrganizationDto(
     int? DefaultMaxPlayers,
     decimal? DefaultCost,
     string? DefaultVenue,
-    string? DefaultVisibility
+    string? DefaultVisibility,
+    string? GroupMeLink = null  // Org-wide GroupMe chat link (events fall back to this)
 );
 
 // Member/subscriber info - visible to all subscribers
@@ -45,7 +46,8 @@ public record CreateOrganizationRequest(
     int? DefaultMaxPlayers,
     decimal? DefaultCost,
     string? DefaultVenue,
-    string? DefaultVisibility
+    string? DefaultVisibility,
+    string? GroupMeLink = null  // Org-wide GroupMe chat link
 );
 
 public record UpdateOrganizationRequest(
@@ -59,7 +61,8 @@ public record UpdateOrganizationRequest(
     int? DefaultMaxPlayers,
     decimal? DefaultCost,
     string? DefaultVenue,
-    string? DefaultVisibility
+    string? DefaultVisibility,
+    string? GroupMeLink = null  // Empty/whitespace clears the link; null leaves it unchanged
 );
 
 public record OrganizationSubscriptionDto(

--- a/apps/api/BHMHockey.Api/Models/Entities/Event.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/Event.cs
@@ -33,6 +33,9 @@ public class Event
     // Optional skill levels - if set, overrides organization's skill levels
     public List<string>? SkillLevels { get; set; }
 
+    // Optional game-specific GroupMe link - overrides the organization's link when set
+    public string? GroupMeLink { get; set; }
+
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 

--- a/apps/api/BHMHockey.Api/Models/Entities/Organization.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/Organization.cs
@@ -22,6 +22,9 @@ public class Organization
     public string? DefaultVenue { get; set; }
     public string? DefaultVisibility { get; set; }  // "Public", "OrganizationMembers", "InviteOnly"
 
+    // Org-wide GroupMe chat link - events fall back to this unless they set their own
+    public string? GroupMeLink { get; set; }
+
     // Navigation properties
     public ICollection<OrganizationSubscription> Subscriptions { get; set; } = new List<OrganizationSubscription>();
     public ICollection<Event> Events { get; set; } = new List<Event>();

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -112,7 +112,8 @@ public class EventService : IEventService
             Cost = request.Cost,
             RegistrationDeadline = request.RegistrationDeadline,
             Visibility = visibility,
-            SkillLevels = request.SkillLevels
+            SkillLevels = request.SkillLevels,
+            GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink)
         };
 
         _context.Events.Add(evt);
@@ -416,6 +417,12 @@ public class EventService : IEventService
         if (request.SlotPositionLabels != null)
         {
             evt.SlotPositionLabels = request.SlotPositionLabels;
+        }
+
+        // Empty/whitespace clears the override (Normalize returns null, falls back to org); null leaves unchanged
+        if (request.GroupMeLink != null)
+        {
+            evt.GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink);
         }
 
         evt.UpdatedAt = DateTime.UtcNow;
@@ -946,6 +953,25 @@ public class EventService : IEventService
             }
         }
 
+        // Resolve chat link at read time: event override wins, else the org's link (live fallback,
+        // so rotating the org link updates all inheriting events instantly)
+        string? groupMeLink = null;
+        string? groupMeLinkSource = null;
+        if (!string.IsNullOrWhiteSpace(evt.GroupMeLink))
+        {
+            groupMeLink = evt.GroupMeLink;
+            groupMeLinkSource = "event";
+        }
+        else if (evt.OrganizationId.HasValue)
+        {
+            var org = evt.Organization ?? await _context.Organizations.FindAsync(evt.OrganizationId.Value);
+            if (!string.IsNullOrWhiteSpace(org?.GroupMeLink))
+            {
+                groupMeLink = org.GroupMeLink;
+                groupMeLinkSource = "organization";
+            }
+        }
+
         return new EventDto(
             evt.Id,
             evt.OrganizationId,
@@ -975,7 +1001,9 @@ public class EventService : IEventService
             myWaitlistPosition,  // Phase 5 - Waitlist
             myPaymentDeadline,   // Phase 5 - Waitlist
             amIWaitlisted,       // Phase 5 - Waitlist
-            evt.SlotPositionLabels  // Slot position labels
+            evt.SlotPositionLabels,  // Slot position labels
+            groupMeLink,         // Resolved GroupMe chat link
+            groupMeLinkSource    // "event" | "organization" | null
         );
     }
 

--- a/apps/api/BHMHockey.Api/Services/GroupMeLinkValidator.cs
+++ b/apps/api/BHMHockey.Api/Services/GroupMeLinkValidator.cs
@@ -1,0 +1,41 @@
+namespace BHMHockey.Api.Services;
+
+/// <summary>
+/// Normalizes and validates GroupMe chat links for organizations and events.
+/// Empty/whitespace input clears the link (returns null); anything else must be
+/// an https URL on groupme.com (or www.groupme.com).
+/// </summary>
+public static class GroupMeLinkValidator
+{
+    private const int MaxLength = 500;
+    private static readonly HashSet<string> ValidHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "groupme.com",
+        "www.groupme.com"
+    };
+
+    /// <summary>
+    /// Returns the trimmed link, or null when the input is null/empty/whitespace.
+    /// Throws InvalidOperationException for links that aren't https GroupMe URLs.
+    /// </summary>
+    public static string? Normalize(string? link)
+    {
+        if (string.IsNullOrWhiteSpace(link)) return null;
+
+        var trimmed = link.Trim();
+
+        if (trimmed.Length > MaxLength)
+        {
+            throw new InvalidOperationException($"GroupMe link must not exceed {MaxLength} characters.");
+        }
+
+        if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) ||
+            uri.Scheme != Uri.UriSchemeHttps ||
+            !ValidHosts.Contains(uri.Host))
+        {
+            throw new InvalidOperationException("GroupMe link must be an https://groupme.com URL (e.g., https://groupme.com/join_group/...).");
+        }
+
+        return trimmed;
+    }
+}

--- a/apps/api/BHMHockey.Api/Services/OrganizationService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationService.cs
@@ -105,7 +105,8 @@ public class OrganizationService : IOrganizationService
             DefaultMaxPlayers = request.DefaultMaxPlayers,
             DefaultCost = request.DefaultCost,
             DefaultVenue = request.DefaultVenue,
-            DefaultVisibility = request.DefaultVisibility
+            DefaultVisibility = request.DefaultVisibility,
+            GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink)
         };
 
         _context.Organizations.Add(organization);
@@ -201,6 +202,8 @@ public class OrganizationService : IOrganizationService
         if (request.DefaultCost != null) organization.DefaultCost = request.DefaultCost;
         if (request.DefaultVenue != null) organization.DefaultVenue = request.DefaultVenue;
         if (request.DefaultVisibility != null) organization.DefaultVisibility = request.DefaultVisibility;
+        // Empty/whitespace clears the link (Normalize returns null); null leaves it unchanged
+        if (request.GroupMeLink != null) organization.GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink);
 
         organization.UpdatedAt = DateTime.UtcNow;
 
@@ -431,7 +434,8 @@ public class OrganizationService : IOrganizationService
             org.DefaultMaxPlayers,
             org.DefaultCost,
             org.DefaultVenue,
-            org.DefaultVisibility
+            org.DefaultVisibility,
+            org.GroupMeLink
         );
     }
 }

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -324,7 +324,7 @@ export default function EventDetailScreen() {
       case 'roster':
         return <EventRosterTab eventId={id} event={selectedEvent} canManage={canManage} />;
       case 'chat':
-        return <EventChatTab />;
+        return <EventChatTab event={selectedEvent} />;
       default:
         return null;
     }

--- a/apps/mobile/app/events/create.tsx
+++ b/apps/mobile/app/events/create.tsx
@@ -29,6 +29,7 @@ export default function CreateEventScreen() {
       visibility: data.visibility,
       skillLevels: data.skillLevels,
       applyAutoRoster: data.applyAutoRoster,
+      groupMeLink: data.groupMeLink || undefined,
     });
 
     if (result) {

--- a/apps/mobile/app/events/edit.tsx
+++ b/apps/mobile/app/events/edit.tsx
@@ -51,6 +51,8 @@ export default function EditEventScreen() {
         cost: data.cost,
         visibility: data.visibility,
         skillLevels: data.skillLevels,
+        // '' clears the event's own link (falls back to org); a value sets the override
+        groupMeLink: data.groupMeLink,
       });
 
       Alert.alert('Success', 'Event updated successfully!', [

--- a/apps/mobile/app/organizations/[id]/settings.tsx
+++ b/apps/mobile/app/organizations/[id]/settings.tsx
@@ -19,6 +19,7 @@ import { Picker } from '@react-native-picker/picker';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { organizationService } from '@bhmhockey/api-client';
 import type { Organization, EventVisibility } from '@bhmhockey/shared';
+import { isValidGroupMeLink, GROUPME_LINK_ERROR } from '../../../utils/groupme';
 import { colors, spacing, radius } from '../../../theme';
 
 const DAYS_OF_WEEK = [
@@ -55,6 +56,7 @@ export default function OrganizationSettingsScreen() {
   const [defaultCost, setDefaultCost] = useState('');
   const [defaultVenue, setDefaultVenue] = useState('');
   const [defaultVisibility, setDefaultVisibility] = useState<EventVisibility | null>(null);
+  const [groupMeLink, setGroupMeLink] = useState('');
 
   // UI state
   const [showDayPicker, setShowDayPicker] = useState(false);
@@ -101,6 +103,7 @@ export default function OrganizationSettingsScreen() {
       setDefaultCost(toStr(org.defaultCost));
       setDefaultVenue(org.defaultVenue ?? '');
       setDefaultVisibility(org.defaultVisibility ?? null);
+      setGroupMeLink(org.groupMeLink ?? '');
     } catch (error) {
       Alert.alert('Error', 'Failed to load organization');
       router.back();
@@ -167,6 +170,12 @@ export default function OrganizationSettingsScreen() {
       }
     }
 
+    // GroupMe link validation (if provided)
+    if (groupMeLink.trim() && !isValidGroupMeLink(groupMeLink)) {
+      Alert.alert('Error', GROUPME_LINK_ERROR);
+      return false;
+    }
+
     return true;
   };
 
@@ -192,6 +201,8 @@ export default function OrganizationSettingsScreen() {
         defaultCost: parseFloatOrNull(defaultCost),
         defaultVenue: defaultVenue.trim() || null,
         defaultVisibility,
+        // '' clears the org's link (backend stores null); a value sets it
+        groupMeLink: groupMeLink.trim(),
       });
 
       Alert.alert('Success', 'Event defaults updated successfully', [
@@ -361,6 +372,27 @@ export default function OrganizationSettingsScreen() {
               onSubmitEditing={() => Keyboard.dismiss()}
               inputAccessoryViewID={inputAccessoryViewID}
             />
+          </View>
+
+          {/* GroupMe Link */}
+          <View style={styles.field}>
+            <Text style={styles.label}>GroupMe Link</Text>
+            <TextInput
+              style={styles.input}
+              value={groupMeLink}
+              onChangeText={setGroupMeLink}
+              placeholder="https://groupme.com/join_group/..."
+              placeholderTextColor={colors.text.muted}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+              returnKeyType="done"
+              onSubmitEditing={() => Keyboard.dismiss()}
+              inputAccessoryViewID={inputAccessoryViewID}
+            />
+            <Text style={styles.fieldHint} allowFontScaling={false}>
+              Used for all of this org's events unless an event sets its own link
+            </Text>
           </View>
 
           {/* Visibility */}
@@ -535,6 +567,11 @@ const styles = StyleSheet.create({
   },
   placeholderText: {
     color: colors.text.muted,
+  },
+  fieldHint: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: spacing.xs,
   },
   pickerArrow: {
     fontSize: 12,

--- a/apps/mobile/components/EventForm.tsx
+++ b/apps/mobile/components/EventForm.tsx
@@ -20,6 +20,7 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import type { EventVisibility, SkillLevel, EventDto, Organization } from '@bhmhockey/shared';
 import { SkillLevelSelector } from './SkillLevelSelector';
 import { useOrganizationStore } from '../stores/organizationStore';
+import { isValidGroupMeLink, GROUPME_LINK_ERROR } from '../utils/groupme';
 import { colors, spacing, radius } from '../theme';
 
 // Platform-specific Picker props for dark theme
@@ -43,6 +44,7 @@ export interface EventFormData {
   visibility: EventVisibility;
   skillLevels?: SkillLevel[];
   applyAutoRoster?: boolean;
+  groupMeLink?: string;  // '' clears the event's own link (inherits org's); trimmed value sets it
 }
 
 interface EventFormProps {
@@ -76,6 +78,7 @@ export function EventForm({
   const [visibility, setVisibility] = useState<EventVisibility>('Public');
   const [skillLevels, setSkillLevels] = useState<SkillLevel[]>([]);
   const [applyAutoRoster, setApplyAutoRoster] = useState(true);
+  const [groupMeLink, setGroupMeLink] = useState('');
 
   // Auto-roster of the selected org (create mode only, admin-only endpoint)
   const autoRoster = useOrganizationStore((state) => state.autoRoster);
@@ -116,6 +119,8 @@ export function EventForm({
       setCost(String(initialData.cost));
       setVisibility(initialData.visibility as EventVisibility);
       setSkillLevels((initialData.skillLevels as SkillLevel[]) || []);
+      // Only pre-fill the event's OWN link - an inherited org link stays blank (blank means inherit)
+      setGroupMeLink(initialData.groupMeLinkSource === 'event' ? initialData.groupMeLink || '' : '');
     }
   }, [initialData]);
 
@@ -220,6 +225,18 @@ export function EventForm({
     ? !!initialData?.organizationId
     : !!selectedOrgId;
 
+  // When the GroupMe field is blank, the event inherits the org's link - name the org for the hint.
+  // Create mode: from the selected org; edit mode: from the resolved link's source on the event.
+  const inheritedGroupMeOrgName = !groupMeLink.trim()
+    ? (mode === 'create'
+        ? (organizations.find(o => o.id === selectedOrgId)?.groupMeLink
+            ? organizations.find(o => o.id === selectedOrgId)?.name
+            : undefined)
+        : (initialData?.groupMeLinkSource === 'organization'
+            ? initialData.organizationName || 'your organization'
+            : undefined))
+    : undefined;
+
   // Get display names for pickers
   const getOrgDisplayName = () => {
     if (!orgSelectionMade) return 'Select...';
@@ -307,6 +324,11 @@ export function EventForm({
       Alert.alert('Error', 'Please enter a cost (0 for free events)');
       return false;
     }
+    // GroupMe link is optional, but if provided must be a valid GroupMe URL
+    if (groupMeLink.trim() && !isValidGroupMeLink(groupMeLink)) {
+      Alert.alert('Error', GROUPME_LINK_ERROR);
+      return false;
+    }
     return true;
   };
 
@@ -325,6 +347,7 @@ export function EventForm({
       visibility,
       skillLevels: skillLevels.length > 0 ? skillLevels : undefined,
       applyAutoRoster: selectedOrgId ? applyAutoRoster : undefined,
+      groupMeLink: groupMeLink.trim(),
     };
 
     await onSubmit(formData);
@@ -523,6 +546,29 @@ export function EventForm({
           </View>
         </View>
 
+
+        {/* GroupMe Link */}
+        <View style={styles.field}>
+          <Text style={styles.label}>GroupMe Link (optional)</Text>
+          <TextInput
+            style={styles.input}
+            value={groupMeLink}
+            onChangeText={setGroupMeLink}
+            placeholder="https://groupme.com/join_group/..."
+            placeholderTextColor={colors.text.muted}
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            returnKeyType="done"
+            onSubmitEditing={() => Keyboard.dismiss()}
+            inputAccessoryViewID={inputAccessoryViewID}
+          />
+          {inheritedGroupMeOrgName && (
+            <Text style={styles.skillNote} allowFontScaling={false}>
+              Using {inheritedGroupMeOrgName}'s GroupMe link
+            </Text>
+          )}
+        </View>
 
         {/* Auto-Roster Toggle (create mode, org events with a non-empty auto-roster) */}
         {mode === 'create' && !!selectedOrgId && autoRosterCount > 0 && (

--- a/apps/mobile/components/event-detail/EventChatTab.tsx
+++ b/apps/mobile/components/event-detail/EventChatTab.tsx
@@ -1,15 +1,69 @@
-import { View, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Linking, Alert } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import type { EventDto } from '@bhmhockey/shared';
 import { EmptyState } from '../EmptyState';
-import { colors } from '../../theme';
+import { Badge } from '../Badge';
+import { colors, spacing, radius } from '../../theme';
 
-export function EventChatTab() {
+interface EventChatTabProps {
+  event: EventDto;
+}
+
+export function EventChatTab({ event }: EventChatTabProps) {
+  const router = useRouter();
+  const link = event.groupMeLink;
+
+  if (!link) {
+    return (
+      <View style={styles.container}>
+        <EmptyState
+          icon="chatbubble-outline"
+          title="No Chat Link Yet"
+          message={
+            event.canManage
+              ? 'Add a GroupMe link to this event, or set an org-wide link in your organization settings.'
+              : "The organizer hasn't added a GroupMe chat link for this event yet."
+          }
+          actionLabel={event.canManage ? 'Add GroupMe Link' : undefined}
+          onAction={event.canManage ? () => router.push(`/events/edit?id=${event.id}`) : undefined}
+        />
+      </View>
+    );
+  }
+
+  const isOrgChat = event.groupMeLinkSource === 'organization';
+
+  const handleOpenGroupMe = async () => {
+    try {
+      await Linking.openURL(link);
+    } catch (error) {
+      Alert.alert('Error', 'Could not open the GroupMe link.');
+    }
+  };
+
   return (
     <View style={styles.container}>
-      <EmptyState
-        icon="chatbubble-outline"
-        title="Chat Coming Soon"
-        message="Group chat for event participants will be available in a future update."
-      />
+      <View style={styles.card}>
+        <Ionicons name="chatbubbles" size={48} color={colors.primary.teal} style={styles.icon} />
+        <Text style={styles.title} allowFontScaling={false}>
+          GroupMe
+        </Text>
+        <Badge variant={isOrgChat ? 'purple' : 'teal'}>
+          {isOrgChat ? 'Organization Chat' : 'Event Chat'}
+        </Badge>
+        <Text style={styles.message} allowFontScaling={false}>
+          {isOrgChat
+            ? `This game uses ${event.organizationName || 'the organization'}'s org-wide GroupMe chat.`
+            : 'This game has its own GroupMe chat.'}
+        </Text>
+        <TouchableOpacity style={styles.openButton} onPress={handleOpenGroupMe}>
+          <Ionicons name="open-outline" size={18} color={colors.bg.darkest} />
+          <Text style={styles.openButtonText} allowFontScaling={false}>
+            Open GroupMe
+          </Text>
+        </TouchableOpacity>
+      </View>
     </View>
   );
 }
@@ -19,5 +73,44 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.bg.darkest,
     justifyContent: 'center',
+    padding: spacing.md,
+  },
+  card: {
+    backgroundColor: colors.bg.dark,
+    borderRadius: radius.lg,
+    padding: spacing.xl,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.border.default,
+  },
+  icon: {
+    marginBottom: spacing.md,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.text.primary,
+    marginBottom: spacing.sm,
+  },
+  message: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    textAlign: 'center',
+    marginTop: spacing.md,
+  },
+  openButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.lg,
+    backgroundColor: colors.primary.teal,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+  },
+  openButtonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.bg.darkest,
   },
 });

--- a/apps/mobile/utils/groupme.ts
+++ b/apps/mobile/utils/groupme.ts
@@ -1,0 +1,12 @@
+// Client-side mirror of the backend's GroupMeLinkValidator:
+// links must be https URLs on groupme.com (or www.groupme.com), max 500 chars.
+// The backend is authoritative - this just gives users a friendly error before submitting.
+const GROUPME_LINK_PATTERN = /^https:\/\/(www\.)?groupme\.com([/?#]|$)/i;
+
+export const GROUPME_LINK_ERROR =
+  'GroupMe link must be an https://groupme.com URL (e.g., https://groupme.com/join_group/...)';
+
+export function isValidGroupMeLink(link: string): boolean {
+  const trimmed = link.trim();
+  return trimmed.length <= 500 && GROUPME_LINK_PATTERN.test(trimmed);
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -57,6 +57,7 @@ export interface Organization {
   defaultCost?: number | null;
   defaultVenue?: string | null;
   defaultVisibility?: EventVisibility | null;
+  groupMeLink?: string | null;  // Org-wide GroupMe chat link (events fall back to this)
 }
 
 // Organization admin info
@@ -132,6 +133,7 @@ export interface CreateOrganizationRequest {
   defaultCost?: number | null;
   defaultVenue?: string | null;
   defaultVisibility?: EventVisibility | null;
+  groupMeLink?: string | null;  // Org-wide GroupMe chat link
 }
 
 export interface UpdateOrganizationRequest {
@@ -147,6 +149,7 @@ export interface UpdateOrganizationRequest {
   defaultCost?: number | null;
   defaultVenue?: string | null;
   defaultVisibility?: EventVisibility | null;
+  groupMeLink?: string | null;  // Empty/whitespace clears the link; null/undefined leaves it unchanged
 }
 
 // Event types
@@ -236,6 +239,9 @@ export interface EventDto {
   amIWaitlisted: boolean;        // Convenience flag - true if current user is on waitlist
   // Slot position labels (organizer feature)
   slotPositionLabels?: Record<number, string>; // Maps slot index to position label (e.g., {1: "C", 2: "LW"})
+  // GroupMe chat link, resolved server-side at read time: event override wins, else org's link
+  groupMeLink?: string | null;
+  groupMeLinkSource?: 'event' | 'organization' | null; // Where the resolved link came from
 }
 
 // EventRegistrationDto - API response for registration with user details
@@ -276,6 +282,7 @@ export interface CreateEventRequest {
   visibility?: EventVisibility;  // Default: 'Public'
   skillLevels?: SkillLevel[];    // Optional - overrides org's skill levels if set
   applyAutoRoster?: boolean;     // Auto-add the org's auto-roster members (default true; ignored for standalone events)
+  groupMeLink?: string;          // Optional game-specific GroupMe link (blank inherits org's link)
 }
 
 export interface UpdateEventRequest {
@@ -291,6 +298,7 @@ export interface UpdateEventRequest {
   visibility?: EventVisibility;  // Can change visibility after creation
   skillLevels?: SkillLevel[];    // Can change skill levels after creation
   slotPositionLabels?: Record<number, string>;  // Slot position labels (e.g., {1: "C", 2: "LW"})
+  groupMeLink?: string;          // Empty string clears the override (falls back to org); undefined leaves unchanged
 }
 
 // Payment request types (Phase 4)


### PR DESCRIPTION
## Summary

In-app chat is deferred; this replaces the event page's "Chat Coming Soon" tab with GroupMe deep links. Organizations set one org-wide GroupMe link; individual events can override it with a game-specific link.

## Behavior

- Nullable `GroupMeLink` on Organization and Event (additive-only migration, two text columns).
- **Live fallback resolved at read time**: an event with no link shows the org's *current* link (`GroupMeLinkSource` = "organization" | "event" | null on EventDto). Rotating the org link instantly updates every inheriting event. Standalone events have no fallback.
- GroupMe-only validation on all write paths: https, groupme.com host, trimmed, max 500; empty clears to null. Client-side mirror in `utils/groupme.ts` for friendly form errors (backend authoritative).
- Mobile: GroupMe Link field in org Event Defaults settings; optional override field on the event form ("blank = inherit", with a "Using {org}'s GroupMe link" hint); Chat tab now shows an Organization Chat / Event Chat badge and an "Open GroupMe" button via `Linking.openURL`, with an admin CTA when no link exists.
- Side fix: Events/Organizations Create/Update endpoints previously let validation exceptions escape as 500s; they now map `InvalidOperationException` → 400 with `LogWarning`, per repo conventions.
- DTOs mirrored in `@bhmhockey/shared`. No `UserDto` changes, no notification changes, no new dependencies.

## Testing

- API suite: 931 → 960 (+29: fallback resolution incl. override-wins/org-fallback/standalone/source labeling, validation accept+reject, write paths, controller 400 mapping)
- Frontend suites all pass (shared 41, api-client 26, mobile 85); mobile type-check clean
- Live E2E verified: inherit, override, org-link rotation propagating to inheriting events, override clearing, standalone behavior, and validation rejections — against a throwaway org, cleaned up afterward
- Manually tested in the iOS simulator by @auc0le (org link set/rotate, inherit/override badges, empty states, validation errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)