### PR TITLE
Add waitlist visibility setting and payment guidance

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Controllers/EventsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/EventsControllerTests.cs
@@ -63,7 +63,10 @@ public class EventsControllerTests
         Guid? organizationId = null,
         string? organizationName = "Test Organization",
         string visibility = "Public",
-        bool isCreator = false)
+        bool isCreator = false,
+        bool isRosterPublished = true,
+        bool amIWaitlisted = false,
+        bool showWaitlistBeforePublish = false)
     {
         // If useDefaultOrg is true and no explicit org is passed, use _testOrgId
         // If useDefaultOrg is false or explicit null is passed, use null
@@ -89,7 +92,7 @@ public class EventsControllerTests
             IsRegistered: isRegistered,
             CanManage: isCreator,
             CreatedAt: DateTime.UtcNow,
-            IsRosterPublished: true,     // Roster draft mode
+            IsRosterPublished: isRosterPublished,  // Roster draft mode
             CreatorVenmoHandle: null,    // Phase 4
             MyPaymentStatus: null,       // Phase 4
             MyTeamAssignment: null,      // Team assignment
@@ -97,8 +100,9 @@ public class EventsControllerTests
             WaitlistCount: 0,            // Phase 5 - Waitlist
             MyWaitlistPosition: null,    // Phase 5 - Waitlist
             MyPaymentDeadline: null,     // Phase 5 - Waitlist
-            AmIWaitlisted: false,        // Phase 5 - Waitlist
-            SlotPositionLabels: null     // Slot position labels
+            AmIWaitlisted: amIWaitlisted,  // Phase 5 - Waitlist
+            SlotPositionLabels: null,    // Slot position labels
+            ShowWaitlistBeforePublish: showWaitlistBeforePublish  // Pre-publish waitlist visibility
         );
     }
 
@@ -575,6 +579,126 @@ public class EventsControllerTests
         returnedRegistrations.Should().HaveCount(1);
     }
 
+    private List<EventRegistrationDto> CreateWaitlistDtos()
+    {
+        return new List<EventRegistrationDto>
+        {
+            new EventRegistrationDto(
+                Id: Guid.NewGuid(),
+                EventId: _testEventId,
+                User: CreateUserDto(Guid.NewGuid()),
+                Status: "Waitlisted",
+                RegisteredAt: DateTime.UtcNow,
+                RegisteredPosition: "Skater",
+                PaymentStatus: null,           // Payment info stripped pre-publish
+                PaymentMarkedAt: null,
+                PaymentVerifiedAt: null,
+                TeamAssignment: null,
+                RosterOrder: null,
+                WaitlistPosition: 1,
+                PromotedAt: null,
+                PaymentDeadlineAt: null,
+                IsWaitlisted: true
+            )
+        };
+    }
+
+    [Fact]
+    public async Task GetRegistrations_Unpublished_SettingOn_RegisteredViewer_ReturnsPrePublishWaitlist()
+    {
+        // Arrange
+        SetupAuthenticatedUser();
+        _mockEventService.Setup(s => s.GetByIdAsync(_testEventId, _testUserId))
+            .ReturnsAsync(CreateEventDto(isRosterPublished: false, showWaitlistBeforePublish: true, isRegistered: true));
+        _mockEventService.Setup(s => s.GetPrePublishWaitlistAsync(_testEventId))
+            .ReturnsAsync(CreateWaitlistDtos());
+
+        // Act
+        var result = await _controller.GetRegistrations(_testEventId);
+
+        // Assert - waitlist-only view; full roster endpoint is never used
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var returned = okResult.Value.Should().BeAssignableTo<List<EventRegistrationDto>>().Subject;
+        returned.Should().HaveCount(1);
+        returned[0].IsWaitlisted.Should().BeTrue();
+        _mockEventService.Verify(s => s.GetRegistrationsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetRegistrations_Unpublished_SettingOn_WaitlistedViewer_ReturnsPrePublishWaitlist()
+    {
+        // Arrange
+        SetupAuthenticatedUser();
+        _mockEventService.Setup(s => s.GetByIdAsync(_testEventId, _testUserId))
+            .ReturnsAsync(CreateEventDto(isRosterPublished: false, showWaitlistBeforePublish: true, amIWaitlisted: true));
+        _mockEventService.Setup(s => s.GetPrePublishWaitlistAsync(_testEventId))
+            .ReturnsAsync(CreateWaitlistDtos());
+
+        // Act
+        var result = await _controller.GetRegistrations(_testEventId);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var returned = okResult.Value.Should().BeAssignableTo<List<EventRegistrationDto>>().Subject;
+        returned.Should().HaveCount(1);
+        _mockEventService.Verify(s => s.GetRegistrationsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetRegistrations_Unpublished_SettingOn_CasualViewer_ReturnsEmpty()
+    {
+        // Arrange - viewer is neither registered nor waitlisted
+        SetupAuthenticatedUser();
+        _mockEventService.Setup(s => s.GetByIdAsync(_testEventId, _testUserId))
+            .ReturnsAsync(CreateEventDto(isRosterPublished: false, showWaitlistBeforePublish: true));
+
+        // Act
+        var result = await _controller.GetRegistrations(_testEventId);
+
+        // Assert - nothing leaks to casual viewers
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var returned = okResult.Value.Should().BeAssignableTo<List<EventRegistrationDto>>().Subject;
+        returned.Should().BeEmpty();
+        _mockEventService.Verify(s => s.GetPrePublishWaitlistAsync(It.IsAny<Guid>()), Times.Never);
+        _mockEventService.Verify(s => s.GetRegistrationsAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetRegistrations_Unpublished_SettingOff_RegisteredViewer_ReturnsEmpty()
+    {
+        // Arrange - today's behavior when the setting is off
+        SetupAuthenticatedUser();
+        _mockEventService.Setup(s => s.GetByIdAsync(_testEventId, _testUserId))
+            .ReturnsAsync(CreateEventDto(isRosterPublished: false, isRegistered: true));
+
+        // Act
+        var result = await _controller.GetRegistrations(_testEventId);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var returned = okResult.Value.Should().BeAssignableTo<List<EventRegistrationDto>>().Subject;
+        returned.Should().BeEmpty();
+        _mockEventService.Verify(s => s.GetPrePublishWaitlistAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetRegistrations_Unpublished_Organizer_ReturnsFullRoster()
+    {
+        // Arrange - canManage always sees everything regardless of the setting
+        SetupAuthenticatedUser();
+        _mockEventService.Setup(s => s.GetByIdAsync(_testEventId, _testUserId))
+            .ReturnsAsync(CreateEventDto(isRosterPublished: false, isCreator: true));
+        _mockEventService.Setup(s => s.GetRegistrationsAsync(_testEventId))
+            .ReturnsAsync(new List<EventRegistrationDto>());
+
+        // Act
+        await _controller.GetRegistrations(_testEventId);
+
+        // Assert
+        _mockEventService.Verify(s => s.GetRegistrationsAsync(_testEventId), Times.Once);
+        _mockEventService.Verify(s => s.GetPrePublishWaitlistAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
     #endregion
 
     #region Payment Tests
@@ -639,6 +763,23 @@ public class EventsControllerTests
 
         // Assert
         result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task MarkPayment_IneligibleWaitlistedPlayer_Returns400WithMessage()
+    {
+        // Arrange - service rejects ineligible waitlisted players with InvalidOperationException
+        SetupAuthenticatedUser();
+        var message = "You're on the waitlist and there isn't an open spot for you yet - don't pay yet. The organizer will reach out if a spot opens.";
+        _mockEventService.Setup(s => s.MarkPaymentAsync(_testEventId, _testUserId, null))
+            .ThrowsAsync(new InvalidOperationException(message));
+
+        // Act
+        var result = await _controller.MarkPayment(_testEventId, null);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value!.ToString().Should().Contain("don't pay yet");
     }
 
     [Fact]

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -772,6 +772,7 @@ public class EventServiceTests : IDisposable
         result.Status.Should().Be("Waitlisted");
         result.WaitlistPosition.Should().Be(1);
         result.Message.Should().Contain("Send your payment to secure your spot");
+        result.PayEligible.Should().BeTrue();
 
         var registration = await _context.EventRegistrations
             .FirstOrDefaultAsync(r => r.EventId == evt.Id && r.UserId == user.Id);
@@ -867,6 +868,7 @@ public class EventServiceTests : IDisposable
         result.Status.Should().Be("Waitlisted");
         result.WaitlistPosition.Should().Be(1);
         result.Message.Should().Contain("Don't pay yet");
+        result.PayEligible.Should().BeFalse();
 
         var registration = await _context.EventRegistrations
             .FirstOrDefaultAsync(r => r.EventId == evt.Id && r.UserId == newUser.Id);

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -2605,7 +2605,7 @@ public class EventServiceTests : IDisposable
         result!.IsRosterPublished.Should().BeFalse();
         result.AmIWaitlisted.Should().BeTrue();  // Registration status visible
         result.MyPaymentStatus.Should().Be("Pending");  // Payment status visible
-        result.MyWaitlistPosition.Should().BeNull();  // Position hidden during draft
+        result.MyWaitlistPosition.Should().Be(1);  // Own position always visible, even during draft
         result.MyTeamAssignment.Should().BeNull();  // Team hidden during draft
         result.CanManage.Should().BeFalse();  // Not organizer
     }
@@ -3756,6 +3756,430 @@ public class EventServiceTests : IDisposable
         await _sut.Invoking(s => s.UpdateAsync(evt.Id, GroupMeLinkUpdateRequest("https://discord.gg/abc"), creator.Id))
             .Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*GroupMe link*");
+    }
+
+    #endregion
+
+    #region Waitlist Visibility & Pay Eligibility Tests
+
+    private async Task<EventRegistration> CreatePositionedRegistration(
+        Guid eventId,
+        Guid userId,
+        string status,
+        string position,
+        int? waitlistPosition = null,
+        string? paymentStatus = null)
+    {
+        var registration = await CreateRegistration(eventId, userId, status);
+        registration.RegisteredPosition = position;
+        registration.WaitlistPosition = waitlistPosition;
+        registration.PaymentStatus = paymentStatus;
+        await _context.SaveChangesAsync();
+        return registration;
+    }
+
+    private static UpdateEventRequest ShowWaitlistUpdateRequest(bool? showWaitlistBeforePublish)
+    {
+        return new UpdateEventRequest(
+            Name: null,
+            Description: null,
+            EventDate: null,
+            Duration: null,
+            Venue: null,
+            MaxPlayers: null,
+            Cost: null,
+            RegistrationDeadline: null,
+            Status: null,
+            Visibility: null,
+            SkillLevels: null,
+            SlotPositionLabels: null,
+            ShowWaitlistBeforePublish: showWaitlistBeforePublish
+        );
+    }
+
+    [Fact]
+    public async Task CreateAsync_DefaultsShowWaitlistBeforePublishToFalse()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateEventRequest(
+            EventDate: DateTime.UtcNow.AddDays(7),
+            MaxPlayers: 10,
+            Cost: 0,
+            Name: "Default Waitlist Visibility Event");
+
+        // Act
+        var result = await _sut.CreateAsync(request, creator.Id);
+
+        // Assert
+        result.ShowWaitlistBeforePublish.Should().BeFalse();
+        var evt = await _context.Events.FindAsync(result.Id);
+        evt!.ShowWaitlistBeforePublish.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithShowWaitlistBeforePublishTrue_SetsFlag()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateEventRequest(
+            EventDate: DateTime.UtcNow.AddDays(7),
+            MaxPlayers: 10,
+            Cost: 0,
+            Name: "Waitlist Visibility Event",
+            ShowWaitlistBeforePublish: true);
+
+        // Act
+        var result = await _sut.CreateAsync(request, creator.Id);
+
+        // Assert
+        result.ShowWaitlistBeforePublish.Should().BeTrue();
+        var evt = await _context.Events.FindAsync(result.Id);
+        evt!.ShowWaitlistBeforePublish.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_TogglesShowWaitlistBeforePublish()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var evt = await CreateTestEvent(creator.Id);
+
+        // Act - turn on
+        var result = await _sut.UpdateAsync(evt.Id, ShowWaitlistUpdateRequest(true), creator.Id);
+
+        // Assert
+        result!.ShowWaitlistBeforePublish.Should().BeTrue();
+
+        // Act - turn back off
+        result = await _sut.UpdateAsync(evt.Id, ShowWaitlistUpdateRequest(false), creator.Id);
+        result!.ShowWaitlistBeforePublish.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NullShowWaitlistBeforePublish_LeavesUnchanged()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var evt = await CreateTestEvent(creator.Id);
+        evt.ShowWaitlistBeforePublish = true;
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.UpdateAsync(evt.Id, ShowWaitlistUpdateRequest(null), creator.Id);
+
+        // Assert
+        result!.ShowWaitlistBeforePublish.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WaitlistedGoalie_PaidEvent_IsPayEligible()
+    {
+        // Arrange - goalies never consume MaxPlayers, so they're always pay-eligible
+        var creator = await CreateTestUser();
+        var goalie = await CreateTestUser("goalie@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 1, cost: 25.00m);
+
+        // Roster full of skaters - irrelevant for a goalie
+        var skater = await CreateTestUser("skater@example.com");
+        await CreatePositionedRegistration(evt.Id, skater.Id, "Registered", "Skater");
+        await CreatePositionedRegistration(evt.Id, goalie.Id, "Waitlisted", "Goalie", waitlistPosition: 1, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, goalie.Id);
+
+        // Assert
+        result!.MyWaitlistPaymentEligible.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WaitlistedSkater_WithinOpenCapacity_IsPayEligible()
+    {
+        // Arrange - 2 open spots (maxPlayers 3, 1 registered skater), waitlist rank 1
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var waitlisted = await CreateTestUser("waitlisted@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 3, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        await CreatePositionedRegistration(evt.Id, waitlisted.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, waitlisted.Id);
+
+        // Assert
+        result!.MyWaitlistPaymentEligible.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WaitlistedSkater_BoundaryRankEqualsOpenSpots_IsPayEligible()
+    {
+        // Arrange - exactly 2 open spots; skater at waitlist rank 2 is the boundary case
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var wl1 = await CreateTestUser("wl1@example.com");
+        var wl2 = await CreateTestUser("wl2@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 3, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        await CreatePositionedRegistration(evt.Id, wl1.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+        await CreatePositionedRegistration(evt.Id, wl2.Id, "Waitlisted", "Skater", waitlistPosition: 2, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, wl2.Id);
+
+        // Assert - rank 2 <= 2 open spots
+        result!.MyWaitlistPaymentEligible.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WaitlistedSkater_BeyondOpenCapacity_NotPayEligible()
+    {
+        // Arrange - 1 open spot (maxPlayers 2, 1 registered skater); skater at rank 2 is too deep
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var wl1 = await CreateTestUser("wl1@example.com");
+        var wl2 = await CreateTestUser("wl2@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 2, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        await CreatePositionedRegistration(evt.Id, wl1.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+        await CreatePositionedRegistration(evt.Id, wl2.Id, "Waitlisted", "Skater", waitlistPosition: 2, paymentStatus: "Pending");
+
+        // Act
+        var eligibleResult = await _sut.GetByIdAsync(evt.Id, wl1.Id);
+        var ineligibleResult = await _sut.GetByIdAsync(evt.Id, wl2.Id);
+
+        // Assert
+        eligibleResult!.MyWaitlistPaymentEligible.Should().BeTrue();
+        ineligibleResult!.MyWaitlistPaymentEligible.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WaitlistedSkater_RosterFull_NotPayEligible()
+    {
+        // Arrange - 0 open spots
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var waitlisted = await CreateTestUser("waitlisted@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 1, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        await CreatePositionedRegistration(evt.Id, waitlisted.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, waitlisted.Id);
+
+        // Assert
+        result!.MyWaitlistPaymentEligible.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WaitlistedSkater_GoalieOnRosterDoesNotConsumeCapacity()
+    {
+        // Arrange - registered goalie doesn't count against MaxPlayers, so a spot stays open
+        var creator = await CreateTestUser();
+        var goalie = await CreateTestUser("goalie@example.com");
+        var waitlisted = await CreateTestUser("waitlisted@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 1, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, goalie.Id, "Registered", "Goalie");
+        await CreatePositionedRegistration(evt.Id, waitlisted.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, waitlisted.Id);
+
+        // Assert
+        result!.MyWaitlistPaymentEligible.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_FreeEvent_WaitlistedUser_EligibilityIsNull()
+    {
+        // Arrange - eligibility only applies to paid events
+        var creator = await CreateTestUser();
+        var waitlisted = await CreateTestUser("waitlisted@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 10, cost: 0);
+
+        await CreatePositionedRegistration(evt.Id, waitlisted.Id, "Waitlisted", "Skater", waitlistPosition: 1);
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, waitlisted.Id);
+
+        // Assert
+        result!.MyWaitlistPaymentEligible.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_RegisteredUser_PaidEvent_EligibilityIsNull()
+    {
+        // Arrange - eligibility only applies to WAITLISTED registrations
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 10, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater", paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, registered.Id);
+
+        // Assert
+        result!.MyWaitlistPaymentEligible.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WaitlistedPlayer_OwnPositionVisibleBeforePublish_SettingOff()
+    {
+        // Arrange - own "#X of Y" is always visible: publish off, visibility setting off
+        var creator = await CreateTestUser();
+        var waitlisted = await CreateTestUser("waitlisted@example.com");
+        var other = await CreateTestUser("other@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 10, cost: 25.00m, isRosterPublished: false);
+
+        await CreatePositionedRegistration(evt.Id, other.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+        await CreatePositionedRegistration(evt.Id, waitlisted.Id, "Waitlisted", "Skater", waitlistPosition: 2, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, waitlisted.Id);
+
+        // Assert
+        result!.IsRosterPublished.Should().BeFalse();
+        result.ShowWaitlistBeforePublish.Should().BeFalse();
+        result.MyWaitlistPosition.Should().Be(2);
+        result.WaitlistCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task MarkPaymentAsync_IneligibleWaitlistedSkater_ThrowsInvalidOperation()
+    {
+        // Arrange - 1 open spot; skater at rank 2 must not be able to self-report payment
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var wl1 = await CreateTestUser("wl1@example.com");
+        var wl2 = await CreateTestUser("wl2@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 2, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        await CreatePositionedRegistration(evt.Id, wl1.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+        var ineligibleReg = await CreatePositionedRegistration(evt.Id, wl2.Id, "Waitlisted", "Skater", waitlistPosition: 2, paymentStatus: "Pending");
+
+        // Act & Assert
+        await _sut.Invoking(s => s.MarkPaymentAsync(evt.Id, wl2.Id, null))
+            .Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*don't pay yet*");
+
+        // Payment status unchanged
+        var updated = await _context.EventRegistrations.FindAsync(ineligibleReg.Id);
+        updated!.PaymentStatus.Should().Be("Pending");
+        updated.PaymentMarkedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task MarkPaymentAsync_EligibleWaitlistedSkater_Succeeds()
+    {
+        // Arrange - 1 open spot; skater at rank 1 can self-report payment
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var wl1 = await CreateTestUser("wl1@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 2, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        var reg = await CreatePositionedRegistration(evt.Id, wl1.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.MarkPaymentAsync(evt.Id, wl1.Id, null);
+
+        // Assert
+        result.Should().BeTrue();
+        var updated = await _context.EventRegistrations.FindAsync(reg.Id);
+        updated!.PaymentStatus.Should().Be("MarkedPaid");
+    }
+
+    [Fact]
+    public async Task MarkPaymentAsync_WaitlistedGoalie_RosterFull_Succeeds()
+    {
+        // Arrange - goalies are always pay-eligible regardless of skater capacity
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var goalie = await CreateTestUser("goalie@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 1, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        var reg = await CreatePositionedRegistration(evt.Id, goalie.Id, "Waitlisted", "Goalie", waitlistPosition: 1, paymentStatus: "Pending");
+
+        // Act
+        var result = await _sut.MarkPaymentAsync(evt.Id, goalie.Id, null);
+
+        // Assert
+        result.Should().BeTrue();
+        var updated = await _context.EventRegistrations.FindAsync(reg.Id);
+        updated!.PaymentStatus.Should().Be("MarkedPaid");
+    }
+
+    [Fact]
+    public async Task UpdatePaymentStatusAsync_IneligibleWaitlistedUser_OrganizerVerifyStillWorks()
+    {
+        // Arrange - organizer paths are exempt from pay-eligibility: verifying a deep-waitlisted
+        // player on a full roster still succeeds (stays waitlisted with Verified status)
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var wl1 = await CreateTestUser("wl1@example.com");
+        var wl2 = await CreateTestUser("wl2@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 1, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater");
+        await CreatePositionedRegistration(evt.Id, wl1.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+        var deepReg = await CreatePositionedRegistration(evt.Id, wl2.Id, "Waitlisted", "Skater", waitlistPosition: 2, paymentStatus: "MarkedPaid");
+
+        // Act
+        var result = await _sut.UpdatePaymentStatusAsync(evt.Id, deepReg.Id, "Verified", creator.Id);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.Promoted.Should().BeFalse(); // Roster full - stays waitlisted
+        var updated = await _context.EventRegistrations.FindAsync(deepReg.Id);
+        updated!.PaymentStatus.Should().Be("Verified");
+        updated.Status.Should().Be("Waitlisted");
+    }
+
+    [Fact]
+    public async Task GetPrePublishWaitlistAsync_ReturnsOrderedWaitlistWithoutPaymentInfo()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var registered = await CreateTestUser("registered@example.com");
+        var wl1 = await CreateTestUser("wl1@example.com");
+        var wl2 = await CreateTestUser("wl2@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 10, cost: 25.00m);
+
+        await CreatePositionedRegistration(evt.Id, registered.Id, "Registered", "Skater", paymentStatus: "Verified");
+        await CreatePositionedRegistration(evt.Id, wl2.Id, "Waitlisted", "Goalie", waitlistPosition: 2, paymentStatus: "MarkedPaid");
+        await CreatePositionedRegistration(evt.Id, wl1.Id, "Waitlisted", "Skater", waitlistPosition: 1, paymentStatus: "Pending");
+
+        // GetWaitlistWithBadgesAsync delegates to the (mocked) waitlist service - back it with the real query
+        _mockWaitlistService.Setup(w => w.GetWaitlistAsync(evt.Id))
+            .ReturnsAsync(await _context.EventRegistrations
+                .Include(r => r.User)
+                .Where(r => r.EventId == evt.Id && r.Status == "Waitlisted")
+                .OrderBy(r => r.WaitlistPosition)
+                .ToListAsync());
+
+        // Act
+        var result = await _sut.GetPrePublishWaitlistAsync(evt.Id);
+
+        // Assert - only waitlisted entries, ordered, names + positions visible, payment stripped
+        result.Should().HaveCount(2);
+        result[0].User.Id.Should().Be(wl1.Id);
+        result[0].WaitlistPosition.Should().Be(1);
+        result[0].RegisteredPosition.Should().Be("Skater");
+        result[1].User.Id.Should().Be(wl2.Id);
+        result[1].WaitlistPosition.Should().Be(2);
+        result[1].RegisteredPosition.Should().Be("Goalie");
+        result.Should().OnlyContain(r => r.PaymentStatus == null
+            && r.PaymentMarkedAt == null
+            && r.PaymentVerifiedAt == null
+            && r.PaymentDeadlineAt == null);
+        result.Should().NotContain(r => r.User.Id == registered.Id);
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -771,7 +771,7 @@ public class EventServiceTests : IDisposable
         // spot is open for their rank, so the message must prompt payment
         result.Status.Should().Be("Waitlisted");
         result.WaitlistPosition.Should().Be(1);
-        result.Message.Should().Contain("Send your payment to secure your spot");
+        result.Message.Should().Contain("Once your payment is verified");
         result.PayEligible.Should().BeTrue();
 
         var registration = await _context.EventRegistrations

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -780,6 +780,71 @@ public class EventServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RegisterAsync_ForPaidEvent_AsEventManager_WithSpot_RegistersDirectlyAsVerified()
+    {
+        // Arrange - Paid event; the creator (manager) registers themselves
+        var creator = await CreateTestUser("creator@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 10, cost: 25.00m);
+
+        // Act
+        var result = await _sut.RegisterAsync(evt.Id, creator.Id);
+
+        // Assert - Straight to roster, payment auto-verified
+        result.Status.Should().Be("Registered");
+        result.WaitlistPosition.Should().BeNull();
+
+        var registration = await _context.EventRegistrations
+            .FirstOrDefaultAsync(r => r.EventId == evt.Id && r.UserId == creator.Id);
+        registration.Should().NotBeNull();
+        registration!.Status.Should().Be("Registered");
+        registration.PaymentStatus.Should().Be("Verified");
+        registration.PaymentVerifiedAt.Should().NotBeNull();
+        registration.TeamAssignment.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ForPaidEvent_AsEventManager_WhenFull_Waitlists()
+    {
+        // Arrange - Paid event with all skater spots taken by Registered players
+        var creator = await CreateTestUser("creator@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 2, cost: 25.00m);
+        var user1 = await CreateTestUser("user1@example.com");
+        var user2 = await CreateTestUser("user2@example.com");
+        await CreateRegistration(evt.Id, user1.Id);
+        await CreateRegistration(evt.Id, user2.Id);
+
+        // Act
+        var result = await _sut.RegisterAsync(evt.Id, creator.Id);
+
+        // Assert - No open spot: manager waitlists like anyone else
+        result.Status.Should().Be("Waitlisted");
+
+        var registration = await _context.EventRegistrations
+            .FirstOrDefaultAsync(r => r.EventId == evt.Id && r.UserId == creator.Id);
+        registration!.Status.Should().Be("Waitlisted");
+        registration.PaymentStatus.Should().Be("Pending");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ForFreeEvent_AsEventManager_RegistersWithoutPaymentTracking()
+    {
+        // Arrange - Free event; manager self-registration gains no payment fields
+        var creator = await CreateTestUser("creator@example.com");
+        var evt = await CreateTestEvent(creator.Id, maxPlayers: 10, cost: 0m);
+
+        // Act
+        var result = await _sut.RegisterAsync(evt.Id, creator.Id);
+
+        // Assert
+        result.Status.Should().Be("Registered");
+
+        var registration = await _context.EventRegistrations
+            .FirstOrDefaultAsync(r => r.EventId == evt.Id && r.UserId == creator.Id);
+        registration!.PaymentStatus.Should().BeNull();
+        registration.PaymentVerifiedAt.Should().BeNull();
+    }
+
+    [Fact]
     public async Task RegisterAsync_ForPaidEvent_WhenFull_Waitlists()
     {
         // Arrange - Paid event that is full

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -767,10 +767,11 @@ public class EventServiceTests : IDisposable
         // Act
         var result = await _sut.RegisterAsync(evt.Id, user.Id);
 
-        // Assert - Should be waitlisted, not registered (paid events always waitlist)
+        // Assert - Should be waitlisted, not registered (paid events always waitlist);
+        // spot is open for their rank, so the message must prompt payment
         result.Status.Should().Be("Waitlisted");
         result.WaitlistPosition.Should().Be(1);
-        result.Message.Should().Contain("payment");
+        result.Message.Should().Contain("Send your payment to secure your spot");
 
         var registration = await _context.EventRegistrations
             .FirstOrDefaultAsync(r => r.EventId == evt.Id && r.UserId == user.Id);
@@ -862,10 +863,10 @@ public class EventServiceTests : IDisposable
         // Act
         var result = await _sut.RegisterAsync(evt.Id, newUser.Id);
 
-        // Assert
+        // Assert - No open spot, so the message must tell them NOT to pay yet
         result.Status.Should().Be("Waitlisted");
         result.WaitlistPosition.Should().Be(1);
-        result.Message.Should().Contain("payment");
+        result.Message.Should().Contain("Don't pay yet");
 
         var registration = await _context.EventRegistrations
             .FirstOrDefaultAsync(r => r.EventId == evt.Id && r.UserId == newUser.Id);

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -935,4 +935,102 @@ public class OrganizationServiceTests : IDisposable
     }
 
     #endregion
+
+    #region DefaultShowWaitlistBeforePublish Tests
+
+    private static UpdateOrganizationRequest ShowWaitlistDefaultUpdateRequest(bool? defaultShowWaitlistBeforePublish)
+    {
+        return new UpdateOrganizationRequest(
+            Name: null,
+            Description: null,
+            Location: null,
+            SkillLevels: null,
+            DefaultDayOfWeek: null,
+            DefaultStartTime: null,
+            DefaultDurationMinutes: null,
+            DefaultMaxPlayers: null,
+            DefaultCost: null,
+            DefaultVenue: null,
+            DefaultVisibility: null,
+            DefaultShowWaitlistBeforePublish: defaultShowWaitlistBeforePublish
+        );
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithDefaultShowWaitlistBeforePublish_StoresAndReturnsIt()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var request = new CreateOrganizationRequest(
+            Name: "Waitlist Default Org",
+            Description: null,
+            Location: null,
+            SkillLevels: null,
+            DefaultDayOfWeek: null,
+            DefaultStartTime: null,
+            DefaultDurationMinutes: null,
+            DefaultMaxPlayers: null,
+            DefaultCost: null,
+            DefaultVenue: null,
+            DefaultVisibility: null,
+            DefaultShowWaitlistBeforePublish: true);
+
+        // Act
+        var result = await _sut.CreateAsync(request, creator.Id);
+
+        // Assert
+        result.DefaultShowWaitlistBeforePublish.Should().BeTrue();
+        var org = await _context.Organizations.FindAsync(result.Id);
+        org!.DefaultShowWaitlistBeforePublish.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_SetsDefaultShowWaitlistBeforePublish_ReturnsItInDto()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+
+        // Act
+        var result = await _sut.UpdateAsync(org.Id, ShowWaitlistDefaultUpdateRequest(true), creator.Id);
+
+        // Assert
+        result!.DefaultShowWaitlistBeforePublish.Should().BeTrue();
+        var updated = await _context.Organizations.FindAsync(org.Id);
+        updated!.DefaultShowWaitlistBeforePublish.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_NullDefaultShowWaitlistBeforePublish_LeavesUnchanged()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+        org.DefaultShowWaitlistBeforePublish = true;
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.UpdateAsync(org.Id, ShowWaitlistDefaultUpdateRequest(null), creator.Id);
+
+        // Assert
+        result!.DefaultShowWaitlistBeforePublish.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsDefaultShowWaitlistBeforePublish()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var org = await CreateTestOrganization(creator.Id);
+        org.DefaultShowWaitlistBeforePublish = true;
+        await _context.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.GetByIdAsync(org.Id, creator.Id);
+
+        // Assert
+        result!.DefaultShowWaitlistBeforePublish.Should().BeTrue();
+    }
+
+    #endregion
 }

--- a/apps/api/BHMHockey.Api.Tests/Services/WaitlistServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/WaitlistServiceTests.cs
@@ -816,7 +816,7 @@ public class WaitlistServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task PromoteFromWaitlistAsync_NotifiesUnverifiedUsers_WhenSpotsRemain()
+    public async Task PromoteFromWaitlistAsync_DoesNotNotifyUnverifiedUsers_WhenSpotsRemain()
     {
         // Arrange - 1 verified user, 3 unverified users, 3 spots open
         var creator = await CreateTestUser("creator@example.com");
@@ -883,7 +883,7 @@ public class WaitlistServiceTests : IDisposable
 
         await _context.SaveChangesAsync();
 
-        // Act - Promote 3 spots (1 verified + 2 unverified notifications)
+        // Act - Promote 3 spots (only the verified user is promoted; unverified users are NOT notified)
         var result = await _sut.PromoteFromWaitlistAsync(evt.Id, spotCount: 3);
 
         // Assert
@@ -891,18 +891,17 @@ public class WaitlistServiceTests : IDisposable
         result.Promoted.Should().HaveCount(1);
         result.Promoted[0].UserId.Should().Be(verifiedUser.Id);
 
-        // 3 notifications: 1 auto-promoted + 2 spot-available (not 3 because only 2 remaining spots)
-        result.PendingNotifications.Should().HaveCount(3);
-        result.PendingNotifications.Count(n => n.Type == NotificationType.AutoPromoted).Should().Be(1);
-        result.PendingNotifications.Count(n => n.Type == NotificationType.SpotAvailable).Should().Be(2);
+        // Only the auto-promoted notification - no spot-available blast to unverified users
+        // (organizer handles all outreach manually)
+        result.PendingNotifications.Should().HaveCount(1);
+        result.PendingNotifications[0].Type.Should().Be(NotificationType.AutoPromoted);
+        result.PendingNotifications[0].User.Id.Should().Be(verifiedUser.Id);
 
-        // Verify unverified users 1 and 2 got notified (in waitlist order)
-        var spotAvailableNotifications = result.PendingNotifications
-            .Where(n => n.Type == NotificationType.SpotAvailable)
-            .ToList();
-        spotAvailableNotifications.Should().Contain(n => n.User.Id == unverifiedUser1.Id);
-        spotAvailableNotifications.Should().Contain(n => n.User.Id == unverifiedUser2.Id);
-        spotAvailableNotifications.Should().NotContain(n => n.User.Id == unverifiedUser3.Id);
+        // Unverified users remain waitlisted and unnotified
+        var unverifiedAfter = await _context.EventRegistrations
+            .Where(r => r.EventId == evt.Id && r.Status == "Waitlisted")
+            .ToListAsync();
+        unverifiedAfter.Should().HaveCount(3);
     }
 
     [Fact]
@@ -1127,40 +1126,56 @@ public class WaitlistServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task SendPendingNotificationsAsync_SendsSpotAvailableNotification()
+    public async Task PromoteFromWaitlistAsync_NeverSendsSpotAvailableNotification()
     {
-        // Arrange
-        // Note: isRosterPublished must be true for notifications to be sent (draft mode suppresses)
+        // Arrange - published paid event, open spots, only an UNVERIFIED waitlisted user
+        // Note: isRosterPublished is true so this is not just draft-mode suppression
         var creator = await CreateTestUser("creator@example.com");
-        var evt = await CreateTestEvent(creator.Id, isRosterPublished: true);
+        var evt = await CreateTestEvent(creator.Id, cost: 25.00m, maxPlayers: 10, isRosterPublished: true);
         var user = await CreateTestUser("user@example.com", pushToken: "ExponentPushToken[user]");
 
-        var notifications = new List<PendingNotification>
+        var reg = new EventRegistration
         {
-            new PendingNotification
-            {
-                User = user,
-                Event = evt,
-                Organizer = creator,
-                Type = NotificationType.SpotAvailable
-            }
+            Id = Guid.NewGuid(),
+            EventId = evt.Id,
+            UserId = user.Id,
+            Status = "Waitlisted",
+            WaitlistPosition = 1,
+            PaymentStatus = "Pending",
+            RegisteredPosition = "Skater",
+            RegisteredAt = DateTime.UtcNow.AddHours(-1)
         };
+        _context.EventRegistrations.Add(reg);
+        await _context.SaveChangesAsync();
 
-        // Act
-        await _sut.SendPendingNotificationsAsync(notifications);
+        // Act - service owns the transaction so any pending notifications WOULD be sent
+        var result = await _sut.PromoteFromWaitlistAsync(evt.Id, spotCount: 1);
 
-        // Assert
+        // Assert - the spot_available blast is gone; the unverified user hears nothing
+        result.Promoted.Should().BeEmpty();
+        result.PendingNotifications.Should().BeEmpty();
+        _mockNotificationService.Verify(
+            n => n.SendPushNotificationAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<object>(),
+                It.IsAny<Guid?>(),
+                "spot_available",
+                It.IsAny<Guid?>(),
+                It.IsAny<Guid?>()),
+            Times.Never);
         _mockNotificationService.Verify(
             n => n.SendPushNotificationAsync(
                 "ExponentPushToken[user]",
-                "Spot Available!",
-                It.Is<string>(s => s.Contains("Complete payment")),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
                 It.IsAny<object>(),
-                user.Id,
-                "spot_available",
-                evt.OrganizationId,
-                evt.Id),
-            Times.Once);
+                It.IsAny<Guid?>(),
+                It.IsAny<string>(),
+                It.IsAny<Guid?>(),
+                It.IsAny<Guid?>()),
+            Times.Never);
     }
 
     #endregion
@@ -1572,7 +1587,7 @@ public class WaitlistServiceTests : IDisposable
     #region PromoteFromWaitlistAsync Additional Tests
 
     [Fact]
-    public async Task PromoteFromWaitlistAsync_NoVerifiedUsers_NotifiesAllUnverifiedNonePromoted()
+    public async Task PromoteFromWaitlistAsync_NoVerifiedUsers_NoPromotionsAndNoNotifications()
     {
         // Arrange - Only unverified users on waitlist, 2 spots available
         var creator = await CreateTestUser("creator@example.com");
@@ -1612,12 +1627,9 @@ public class WaitlistServiceTests : IDisposable
         // Act - 2 spots available, 0 verified users
         var result = await _sut.PromoteFromWaitlistAsync(evt.Id, spotCount: 2);
 
-        // Assert - No promotions, both users notified of available spots
+        // Assert - No promotions and NO spot-available notifications (organizer handles outreach)
         result.Promoted.Should().BeEmpty();
-        result.PendingNotifications.Should().HaveCount(2);
-        result.PendingNotifications.All(n => n.Type == NotificationType.SpotAvailable).Should().BeTrue();
-        result.PendingNotifications.Should().Contain(n => n.User.Id == unverifiedUser1.Id);
-        result.PendingNotifications.Should().Contain(n => n.User.Id == unverifiedUser2.Id);
+        result.PendingNotifications.Should().BeEmpty();
 
         // Verify users are still waitlisted (not promoted)
         var reg1After = await _context.EventRegistrations.FirstAsync(r => r.Id == unverifiedReg1.Id);

--- a/apps/api/BHMHockey.Api/Controllers/EventsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/EventsController.cs
@@ -236,6 +236,13 @@ public class EventsController : ControllerBase
             return Ok(await _eventService.GetRegistrationsAsync(id));
         }
 
+        // Pre-publish waitlist visibility: when enabled, viewers registered or waitlisted on the
+        // event see the ordered waitlist (names + positions, no payment info). Roster names stay hidden.
+        if (evt.ShowWaitlistBeforePublish && (evt.IsRegistered || evt.AmIWaitlisted))
+        {
+            return Ok(await _eventService.GetPrePublishWaitlistAsync(id));
+        }
+
         // Non-organizers on unpublished events: empty list
         // (They see their own status via EventDto fields instead)
         return Ok(new List<EventRegistrationDto>());
@@ -319,14 +326,22 @@ public class EventsController : ControllerBase
     {
         var userId = GetCurrentUserId();
 
-        var success = await _eventService.MarkPaymentAsync(id, userId, request?.PaymentReference);
-
-        if (!success)
+        try
         {
-            return BadRequest(new { message = "Unable to mark payment. Registration not found, event is free, or payment already marked." });
-        }
+            var success = await _eventService.MarkPaymentAsync(id, userId, request?.PaymentReference);
 
-        return Ok(new { message = "Payment marked as complete. Awaiting organizer verification." });
+            if (!success)
+            {
+                return BadRequest(new { message = "Unable to mark payment. Registration not found, event is free, or payment already marked." });
+            }
+
+            return Ok(new { message = "Payment marked as complete. Awaiting organizer verification." });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Mark payment rejected for event {EventId}, user {UserId}: {Message}", id, userId, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     /// <summary>

--- a/apps/api/BHMHockey.Api/Migrations/20260717042247_AddWaitlistVisibility.Designer.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717042247_AddWaitlistVisibility.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BHMHockey.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHMHockey.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717042247_AddWaitlistVisibility")]
+    partial class AddWaitlistVisibility
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/BHMHockey.Api/Migrations/20260717042247_AddWaitlistVisibility.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717042247_AddWaitlistVisibility.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHMHockey.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWaitlistVisibility : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "DefaultShowWaitlistBeforePublish",
+                table: "Organizations",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ShowWaitlistBeforePublish",
+                table: "Events",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DefaultShowWaitlistBeforePublish",
+                table: "Organizations");
+
+            migrationBuilder.DropColumn(
+                name: "ShowWaitlistBeforePublish",
+                table: "Events");
+        }
+    }
+}

--- a/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
@@ -156,7 +156,8 @@ public class WaitlistOrderItem
 public record RegistrationResultDto(
     string Status,               // "Registered" or "Waitlisted"
     int? WaitlistPosition,       // Position if waitlisted (null if registered)
-    string Message               // User-friendly message
+    string Message,              // User-friendly message
+    bool? PayEligible = null     // Waitlisted on paid event: may they pay now? (null otherwise)
 );
 
 // Payment update result DTO (Phase 5 - payment verification response)

--- a/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
@@ -38,7 +38,11 @@ public record EventDto(
     Dictionary<int, string>? SlotPositionLabels,  // Maps slot index to position label (e.g., {1: "C", 2: "LW"})
     // GroupMe chat link, resolved at read time: event override wins, else org's link
     string? GroupMeLink = null,
-    string? GroupMeLinkSource = null  // "event" | "organization" | null - where the resolved link came from
+    string? GroupMeLinkSource = null,  // "event" | "organization" | null - where the resolved link came from
+    // Waitlist visibility (pre-publish)
+    bool ShowWaitlistBeforePublish = false,  // Registered/waitlisted viewers can see the ordered waitlist before publish
+    // Pay-eligibility for the current user's waitlisted registration on paid events
+    bool? MyWaitlistPaymentEligible = null   // null when not applicable (not waitlisted or free event)
 );
 
 public record CreateEventRequest(
@@ -54,7 +58,8 @@ public record CreateEventRequest(
     string? Visibility = "Public",       // Default to public if not specified
     List<string>? SkillLevels = null,    // Optional - overrides org's skill levels if set
     bool ApplyAutoRoster = true,         // Auto-add the org's auto-roster members (ignored for standalone events)
-    string? GroupMeLink = null           // Optional game-specific GroupMe link (blank inherits org's link)
+    string? GroupMeLink = null,          // Optional game-specific GroupMe link (blank inherits org's link)
+    bool? ShowWaitlistBeforePublish = null  // Optional - defaults to false (client pre-fills from org default)
 );
 
 public record UpdateEventRequest(
@@ -70,7 +75,8 @@ public record UpdateEventRequest(
     string? Visibility,                            // Can change visibility after creation
     List<string>? SkillLevels,                     // Can change skill levels after creation
     Dictionary<int, string>? SlotPositionLabels,  // Slot position labels (e.g., {1: "C", 2: "LW"})
-    string? GroupMeLink = null                    // Empty/whitespace clears the override (falls back to org); null leaves unchanged
+    string? GroupMeLink = null,                   // Empty/whitespace clears the override (falls back to org); null leaves unchanged
+    bool? ShowWaitlistBeforePublish = null        // null leaves unchanged
 );
 
 public record EventRegistrationDto(

--- a/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
@@ -18,7 +18,8 @@ public record OrganizationDto(
     decimal? DefaultCost,
     string? DefaultVenue,
     string? DefaultVisibility,
-    string? GroupMeLink = null  // Org-wide GroupMe chat link (events fall back to this)
+    string? GroupMeLink = null,  // Org-wide GroupMe chat link (events fall back to this)
+    bool? DefaultShowWaitlistBeforePublish = null  // Pre-fills ShowWaitlistBeforePublish on new events
 );
 
 // Member/subscriber info - visible to all subscribers
@@ -47,7 +48,8 @@ public record CreateOrganizationRequest(
     decimal? DefaultCost,
     string? DefaultVenue,
     string? DefaultVisibility,
-    string? GroupMeLink = null  // Org-wide GroupMe chat link
+    string? GroupMeLink = null,  // Org-wide GroupMe chat link
+    bool? DefaultShowWaitlistBeforePublish = null
 );
 
 public record UpdateOrganizationRequest(
@@ -62,7 +64,8 @@ public record UpdateOrganizationRequest(
     decimal? DefaultCost,
     string? DefaultVenue,
     string? DefaultVisibility,
-    string? GroupMeLink = null  // Empty/whitespace clears the link; null leaves it unchanged
+    string? GroupMeLink = null,  // Empty/whitespace clears the link; null leaves it unchanged
+    bool? DefaultShowWaitlistBeforePublish = null  // null leaves unchanged
 );
 
 public record OrganizationSubscriptionDto(

--- a/apps/api/BHMHockey.Api/Models/Entities/Event.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/Event.cs
@@ -24,6 +24,10 @@ public class Event
     // New events start unpublished; organizers must publish before players see placements
     public bool IsRosterPublished { get; set; } = false;
 
+    // When true, registered/waitlisted players can see the ordered waitlist (names + positions,
+    // no payment info) before the roster is published. Roster names stay hidden until publish.
+    public bool ShowWaitlistBeforePublish { get; set; } = false;
+
     // Visibility controls who can see and register for the event
     // - Public: Anyone can see and register
     // - OrganizationMembers: Only subscribers of the organization (requires OrganizationId)

--- a/apps/api/BHMHockey.Api/Models/Entities/Organization.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/Organization.cs
@@ -21,6 +21,7 @@ public class Organization
     public decimal? DefaultCost { get; set; }
     public string? DefaultVenue { get; set; }
     public string? DefaultVisibility { get; set; }  // "Public", "OrganizationMembers", "InviteOnly"
+    public bool? DefaultShowWaitlistBeforePublish { get; set; }  // Pre-fills ShowWaitlistBeforePublish on new events
 
     // Org-wide GroupMe chat link - events fall back to this unless they set their own
     public string? GroupMeLink { get; set; }

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -496,9 +496,13 @@ public class EventService : IEventService
         bool isFull = registeredPosition == "Goalie" ? false : skaterCount >= evt.MaxPlayers;
         bool isPaidEvent = evt.Cost > 0;
 
+        // Event managers self-registering skip payment verification: they roster
+        // directly as Verified when a spot is open (they'd be verifying themselves)
+        bool isManager = await CanUserManageEventAsync(evt, userId);
+
         // Paid events: ALWAYS waitlist first (organizer verifies payment before adding to roster)
         // Free events: Only waitlist if roster is full
-        if (isPaidEvent || isFull)
+        if ((isPaidEvent && !isManager) || isFull)
         {
             // Add to waitlist
             var waitlistPosition = await _waitlistService.GetNextWaitlistPositionAsync(eventId);
@@ -550,8 +554,11 @@ public class EventService : IEventService
         }
         else
         {
-            // Free event with available capacity: register directly
+            // Open spot with no payment barrier (free event, or a manager
+            // self-registering on a paid event - auto-verified): register directly
             var teamAssignment = await DetermineTeamAssignmentAsync(eventId, registeredPosition);
+            var paymentStatus = isPaidEvent ? "Verified" : null;
+            DateTime? paymentVerifiedAt = isPaidEvent ? DateTime.UtcNow : null;
 
             if (existingReg != null)
             {
@@ -561,9 +568,9 @@ public class EventService : IEventService
                 existingReg.RegisteredPosition = registeredPosition;
                 existingReg.TeamAssignment = teamAssignment;
                 existingReg.WaitlistPosition = null;
-                existingReg.PaymentStatus = null; // Free event, no payment tracking
+                existingReg.PaymentStatus = paymentStatus;
                 existingReg.PaymentMarkedAt = null;
-                existingReg.PaymentVerifiedAt = null;
+                existingReg.PaymentVerifiedAt = paymentVerifiedAt;
                 existingReg.PromotedAt = null;
                 existingReg.PaymentDeadlineAt = null;
             }
@@ -576,7 +583,8 @@ public class EventService : IEventService
                     UserId = userId,
                     RegisteredPosition = registeredPosition,
                     TeamAssignment = teamAssignment,
-                    PaymentStatus = null // Free event, no payment tracking
+                    PaymentStatus = paymentStatus,
+                    PaymentVerifiedAt = paymentVerifiedAt
                 };
                 _context.EventRegistrations.Add(registration);
             }

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -507,6 +507,7 @@ public class EventService : IEventService
             // Add to waitlist
             var waitlistPosition = await _waitlistService.GetNextWaitlistPositionAsync(eventId);
 
+            EventRegistration waitlistReg;
             if (existingReg != null)
             {
                 // Re-activate cancelled registration as waitlisted
@@ -520,6 +521,7 @@ public class EventService : IEventService
                 existingReg.PaymentVerifiedAt = null;
                 existingReg.PromotedAt = null;
                 existingReg.PaymentDeadlineAt = null;
+                waitlistReg = existingReg;
             }
             else
             {
@@ -534,6 +536,7 @@ public class EventService : IEventService
                     PaymentStatus = isPaidEvent ? "Pending" : null
                 };
                 _context.EventRegistrations.Add(registration);
+                waitlistReg = registration;
             }
 
             await _context.SaveChangesAsync();
@@ -541,10 +544,20 @@ public class EventService : IEventService
             // Notify organizer about new waitlist signup
             await NotifyOrganizerNewWaitlistSignupAsync(evt, user, waitlistPosition);
 
-            // Different message for paid events vs full free events
-            var message = isPaidEvent
-                ? "You've been added to the waitlist. Please mark your payment so the organizer can verify and add you to the roster."
-                : $"Event is full. You're #{waitlistPosition} on the waitlist.";
+            // Paid events: tell the player whether to pay now (spot open for their
+            // rank) or hold off (organizer handles outreach when a spot opens)
+            string message;
+            if (isPaidEvent)
+            {
+                var payEligible = await IsWaitlistedRegistrationPayEligibleAsync(evt, waitlistReg);
+                message = payEligible
+                    ? $"You're #{waitlistPosition} on the waitlist. Send your payment to secure your spot - once the organizer verifies it, you'll be added to the roster."
+                    : $"You're #{waitlistPosition} on the waitlist. Don't pay yet - the organizer will reach out if a spot opens.";
+            }
+            else
+            {
+                message = $"Event is full. You're #{waitlistPosition} on the waitlist.";
+            }
 
             return new RegistrationResultDto(
                 "Waitlisted",

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -552,7 +552,7 @@ public class EventService : IEventService
             {
                 payEligible = await IsWaitlistedRegistrationPayEligibleAsync(evt, waitlistReg);
                 message = payEligible.Value
-                    ? $"You're #{waitlistPosition} on the waitlist. Send your payment to secure your spot - once the organizer verifies it, you'll be added to the roster."
+                    ? $"Once your payment is verified, you'll be moved to the roster. Until then you are #{waitlistPosition} on the waitlist but the event is not yet full."
                     : $"You're #{waitlistPosition} on the waitlist. Don't pay yet - the organizer will reach out if a spot opens.";
             }
             else

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -547,10 +547,11 @@ public class EventService : IEventService
             // Paid events: tell the player whether to pay now (spot open for their
             // rank) or hold off (organizer handles outreach when a spot opens)
             string message;
+            bool? payEligible = null;
             if (isPaidEvent)
             {
-                var payEligible = await IsWaitlistedRegistrationPayEligibleAsync(evt, waitlistReg);
-                message = payEligible
+                payEligible = await IsWaitlistedRegistrationPayEligibleAsync(evt, waitlistReg);
+                message = payEligible.Value
                     ? $"You're #{waitlistPosition} on the waitlist. Send your payment to secure your spot - once the organizer verifies it, you'll be added to the roster."
                     : $"You're #{waitlistPosition} on the waitlist. Don't pay yet - the organizer will reach out if a spot opens.";
             }
@@ -562,7 +563,8 @@ public class EventService : IEventService
             return new RegistrationResultDto(
                 "Waitlisted",
                 waitlistPosition,
-                message
+                message,
+                payEligible
             );
         }
         else

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -113,7 +113,8 @@ public class EventService : IEventService
             RegistrationDeadline = request.RegistrationDeadline,
             Visibility = visibility,
             SkillLevels = request.SkillLevels,
-            GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink)
+            GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink),
+            ShowWaitlistBeforePublish = request.ShowWaitlistBeforePublish ?? false
         };
 
         _context.Events.Add(evt);
@@ -423,6 +424,11 @@ public class EventService : IEventService
         if (request.GroupMeLink != null)
         {
             evt.GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink);
+        }
+
+        if (request.ShowWaitlistBeforePublish.HasValue)
+        {
+            evt.ShowWaitlistBeforePublish = request.ShowWaitlistBeforePublish.Value;
         }
 
         evt.UpdatedAt = DateTime.UtcNow;
@@ -798,6 +804,26 @@ public class EventService : IEventService
         }).ToList();
     }
 
+    /// <summary>
+    /// Pre-publish waitlist view for registered/waitlisted (non-manager) viewers when
+    /// ShowWaitlistBeforePublish is on: ordered waitlist with names and registered positions,
+    /// but payment details stripped. Roster (Registered) entries are never included.
+    /// </summary>
+    public async Task<List<EventRegistrationDto>> GetPrePublishWaitlistAsync(Guid eventId)
+    {
+        var waitlist = await GetWaitlistWithBadgesAsync(eventId);
+
+        return waitlist
+            .Select(r => r with
+            {
+                PaymentStatus = null,
+                PaymentMarkedAt = null,
+                PaymentVerifiedAt = null,
+                PaymentDeadlineAt = null
+            })
+            .ToList();
+    }
+
     // Update roster order for multiple registrations (batch update)
     public async Task<bool> UpdateRosterOrderAsync(Guid eventId, List<RosterOrderItem> items, Guid organizerId, Dictionary<int, string>? slotPositionLabels = null)
     {
@@ -935,6 +961,7 @@ public class EventService : IEventService
         int? myWaitlistPosition = null;
         DateTime? myPaymentDeadline = null;
         bool amIWaitlisted = false;
+        bool? myWaitlistPaymentEligible = null;
         if (currentUserId.HasValue)
         {
             var myReg = evt.Registrations?.FirstOrDefault(r => r.UserId == currentUserId.Value && r.Status != "Cancelled")
@@ -945,10 +972,13 @@ public class EventService : IEventService
                 myPaymentDeadline = myReg.PaymentDeadlineAt;
                 amIWaitlisted = myReg.Status == "Waitlisted";
 
-                // Waitlist position only visible if roster is published OR user can manage
-                if (evt.IsRosterPublished || canManage)
+                // Own waitlist position is always visible, even before the roster is published
+                myWaitlistPosition = myReg.WaitlistPosition;
+
+                // Pay-eligibility only applies to waitlisted registrations on paid events
+                if (amIWaitlisted && evt.Cost > 0)
                 {
-                    myWaitlistPosition = myReg.WaitlistPosition;
+                    myWaitlistPaymentEligible = await IsWaitlistedRegistrationPayEligibleAsync(evt, myReg);
                 }
             }
         }
@@ -1003,8 +1033,37 @@ public class EventService : IEventService
             amIWaitlisted,       // Phase 5 - Waitlist
             evt.SlotPositionLabels,  // Slot position labels
             groupMeLink,         // Resolved GroupMe chat link
-            groupMeLinkSource    // "event" | "organization" | null
+            groupMeLinkSource,   // "event" | "organization" | null
+            evt.ShowWaitlistBeforePublish,  // Waitlist visibility (pre-publish)
+            myWaitlistPaymentEligible       // Pay-eligibility for current user's waitlisted spot
         );
+    }
+
+    /// <summary>
+    /// A waitlisted player on a paid event is pay-eligible iff their spot fits open capacity
+    /// for their position type. Goalies never consume MaxPlayers, so they are always eligible.
+    /// Skaters are eligible when their rank among waitlisted skaters (by WaitlistPosition)
+    /// fits within max(0, MaxPlayers - currently registered skater count).
+    /// </summary>
+    private async Task<bool> IsWaitlistedRegistrationPayEligibleAsync(Event evt, EventRegistration registration)
+    {
+        // Goalies don't count against MaxPlayers - always eligible
+        if (registration.RegisteredPosition == "Goalie") return true;
+
+        var registeredSkaterCount = await _context.EventRegistrations
+            .CountAsync(r => r.EventId == evt.Id && r.Status == "Registered" && r.RegisteredPosition != "Goalie");
+        var openSpots = Math.Max(0, evt.MaxPlayers - registeredSkaterCount);
+        if (openSpots == 0) return false;
+
+        // Rank among waitlisted skaters, ordered by waitlist position (1-based)
+        var waitlistedSkaterIds = await _context.EventRegistrations
+            .Where(r => r.EventId == evt.Id && r.Status == "Waitlisted" && r.RegisteredPosition != "Goalie")
+            .OrderBy(r => r.WaitlistPosition)
+            .Select(r => r.Id)
+            .ToListAsync();
+        var rank = waitlistedSkaterIds.IndexOf(registration.Id) + 1;
+
+        return rank > 0 && rank <= openSpots;
     }
 
     // Payment methods (Phase 4)
@@ -1023,6 +1082,18 @@ public class EventService : IEventService
 
         // Can only mark as paid if currently Pending
         if (registration.PaymentStatus != "Pending") return false;
+
+        // Waitlisted players may only self-report payment when their spot fits open capacity.
+        // Organizer paths (verify, move-to-roster, manual add) are intentionally exempt.
+        if (registration.Status == "Waitlisted" &&
+            !await IsWaitlistedRegistrationPayEligibleAsync(registration.Event, registration))
+        {
+            _logger.LogWarning(
+                "MarkPayment rejected for user {UserId} on event {EventId}: waitlist spot does not fit open capacity",
+                userId, eventId);
+            throw new InvalidOperationException(
+                "You're on the waitlist and there isn't an open spot for you yet - don't pay yet. The organizer will reach out if a spot opens.");
+        }
 
         registration.PaymentStatus = "MarkedPaid";
         registration.PaymentMarkedAt = DateTime.UtcNow;

--- a/apps/api/BHMHockey.Api/Services/IEventService.cs
+++ b/apps/api/BHMHockey.Api/Services/IEventService.cs
@@ -47,6 +47,12 @@ public interface IEventService
     Task<List<EventRegistrationDto>> GetWaitlistWithBadgesAsync(Guid eventId);
 
     /// <summary>
+    /// Pre-publish waitlist view for registered/waitlisted viewers when ShowWaitlistBeforePublish
+    /// is on: ordered waitlist with names and positions, payment details stripped.
+    /// </summary>
+    Task<List<EventRegistrationDto>> GetPrePublishWaitlistAsync(Guid eventId);
+
+    /// <summary>
     /// Publish the roster for an event (organizer only).
     /// Sets IsRosterPublished=true, records PublishedAt timestamp, and sends notifications to all players.
     /// Returns failure if roster is already published.

--- a/apps/api/BHMHockey.Api/Services/OrganizationService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationService.cs
@@ -106,6 +106,7 @@ public class OrganizationService : IOrganizationService
             DefaultCost = request.DefaultCost,
             DefaultVenue = request.DefaultVenue,
             DefaultVisibility = request.DefaultVisibility,
+            DefaultShowWaitlistBeforePublish = request.DefaultShowWaitlistBeforePublish,
             GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink)
         };
 
@@ -202,6 +203,7 @@ public class OrganizationService : IOrganizationService
         if (request.DefaultCost != null) organization.DefaultCost = request.DefaultCost;
         if (request.DefaultVenue != null) organization.DefaultVenue = request.DefaultVenue;
         if (request.DefaultVisibility != null) organization.DefaultVisibility = request.DefaultVisibility;
+        if (request.DefaultShowWaitlistBeforePublish != null) organization.DefaultShowWaitlistBeforePublish = request.DefaultShowWaitlistBeforePublish;
         // Empty/whitespace clears the link (Normalize returns null); null leaves it unchanged
         if (request.GroupMeLink != null) organization.GroupMeLink = GroupMeLinkValidator.Normalize(request.GroupMeLink);
 
@@ -435,7 +437,8 @@ public class OrganizationService : IOrganizationService
             org.DefaultCost,
             org.DefaultVenue,
             org.DefaultVisibility,
-            org.GroupMeLink
+            org.GroupMeLink,
+            org.DefaultShowWaitlistBeforePublish
         );
     }
 }

--- a/apps/api/BHMHockey.Api/Services/WaitlistService.cs
+++ b/apps/api/BHMHockey.Api/Services/WaitlistService.cs
@@ -121,7 +121,7 @@ public class WaitlistService : IWaitlistService
             // Notify user their registration was cancelled
             await NotifyRegistrationExpiredAsync(registration);
 
-            // Promote next verified user from waitlist (or notify unverified users of spot)
+            // Promote next verified user from waitlist
             var promotionResult = await PromoteFromWaitlistAsync(registration.EventId, spotCount: 1);
             await SendPendingNotificationsAsync(promotionResult.PendingNotifications);
         }
@@ -304,29 +304,10 @@ public class WaitlistService : IWaitlistService
             eventId: registration.EventId);
     }
 
-    private async Task NotifySpotAvailableAsync(EventRegistration registration)
-    {
-        if (string.IsNullOrEmpty(registration.User.PushToken))
-        {
-            return;
-        }
-
-        var eventName = registration.Event.Name ?? $"Event on {registration.Event.EventDate:MMM d}";
-
-        await _notificationService.SendPushNotificationAsync(
-            registration.User.PushToken,
-            "Spot Available!",
-            $"A spot opened up for {eventName}. Complete payment to secure your spot!",
-            new { eventId = registration.EventId.ToString(), type = "spot_available" },
-            userId: registration.UserId,
-            type: "spot_available",
-            organizationId: registration.Event.OrganizationId,
-            eventId: registration.EventId);
-    }
-
     /// <summary>
-    /// Promotes users from waitlist using priority queue: verified users first (by RegisteredAt),
-    /// then notifies unverified users of available spots (by WaitlistPosition).
+    /// Promotes users from waitlist using priority queue: verified users first (by RegisteredAt).
+    /// Unverified waitlisted users are NOT notified when spots open - the organizer handles all
+    /// outreach manually (capacity often blips transiently while guests are swapped).
     /// </summary>
     /// <param name="eventId">The event ID</param>
     /// <param name="spotCount">Number of spots to fill</param>
@@ -374,32 +355,8 @@ public class WaitlistService : IWaitlistService
             spotsRemaining--;
         }
 
-        // If spots remain, notify unverified users (by WaitlistPosition order)
-        if (spotsRemaining > 0)
-        {
-            var unverifiedUsers = await _context.EventRegistrations
-                .Include(r => r.User)
-                .Include(r => r.Event)
-                    .ThenInclude(e => e.Creator)
-                .Where(r => r.EventId == eventId
-                         && r.Status == "Waitlisted"
-                         && r.PaymentStatus != "Verified")
-                .OrderBy(r => r.WaitlistPosition)
-                .ThenBy(r => r.Id)
-                .Take(spotsRemaining)
-                .ToListAsync();
-
-            foreach (var registration in unverifiedUsers)
-            {
-                result.PendingNotifications.Add(new PendingNotification
-                {
-                    User = registration.User,
-                    Event = registration.Event,
-                    Organizer = registration.Event.Creator,
-                    Type = NotificationType.SpotAvailable
-                });
-            }
-        }
+        // Spots left after promoting verified users go unannounced - no spot_available blast
+        // to unverified users. The organizer reaches out manually if a spot truly opens.
 
         await _context.SaveChangesAsync();
 
@@ -467,23 +424,6 @@ public class WaitlistService : IWaitlistService
                         eventId: notification.Event.Id);
                 }
             }
-            else if (notification.Type == NotificationType.SpotAvailable)
-            {
-                // Send spot available notification to unverified user
-                if (!string.IsNullOrEmpty(notification.User.PushToken))
-                {
-                    var eventName = notification.Event.Name ?? $"Event on {notification.Event.EventDate:MMM d}";
-                    await _notificationService.SendPushNotificationAsync(
-                        notification.User.PushToken,
-                        "Spot Available!",
-                        $"A spot opened up for {eventName}. Complete payment to secure your spot!",
-                        new { eventId = notification.Event.Id.ToString(), type = "spot_available" },
-                        userId: notification.User.Id,
-                        type: "spot_available",
-                        organizationId: notification.Event.OrganizationId,
-                        eventId: notification.Event.Id);
-                }
-            }
         }
     }
 
@@ -538,7 +478,7 @@ public class PromotionResult
     public List<EventRegistration> Promoted { get; set; } = new();
 
     /// <summary>
-    /// Notifications pending to be sent (auto-promoted or spot-available).
+    /// Notifications pending to be sent (auto-promoted).
     /// </summary>
     public List<PendingNotification> PendingNotifications { get; set; } = new();
 }
@@ -560,7 +500,5 @@ public class PendingNotification
 public enum NotificationType
 {
     /// <summary>User was auto-promoted from waitlist.</summary>
-    AutoPromoted,
-    /// <summary>Spot became available for unverified user.</summary>
-    SpotAvailable
+    AutoPromoted
 }

--- a/apps/mobile/CLAUDE.md
+++ b/apps/mobile/CLAUDE.md
@@ -253,7 +253,7 @@ In the roster view (`DraggableRoster`), organizers see payment status badges ins
 | Organizer | `purple` | "Organizer" |
 | Invite Only | `warning` | "Invite Only" |
 
-**Draft Mode Note:** Don't show position numbers or team assignments in badges when `event.isRosterPublished` is false.
+**Draft Mode Note:** Don't show team assignments in badges when `event.isRosterPublished` is false. A player's own waitlist position ("#N Waitlist") is always shown, even pre-publish; the full ordered waitlist shows pre-publish only when the event's `showWaitlistBeforePublish` setting is on and the viewer is registered or waitlisted.
 
 ## Testing
 

--- a/apps/mobile/__tests__/stores/eventStore.test.ts
+++ b/apps/mobile/__tests__/stores/eventStore.test.ts
@@ -15,6 +15,7 @@ const mockRegister = jest.fn();
 const mockCancelRegistration = jest.fn();
 const mockGetMyRegistrations = jest.fn();
 const mockReorderWaitlist = jest.fn();
+const mockMarkPayment = jest.fn();
 
 // Mock the api-client module
 jest.mock('@bhmhockey/api-client', () => ({
@@ -26,6 +27,7 @@ jest.mock('@bhmhockey/api-client', () => ({
     cancelRegistration: mockCancelRegistration,
     getMyRegistrations: mockGetMyRegistrations,
     reorderWaitlist: mockReorderWaitlist,
+    markPayment: mockMarkPayment,
   },
 }));
 
@@ -64,6 +66,8 @@ const createMockEvent = (overrides: Partial<EventDto> = {}): EventDto => ({
   amIWaitlisted: false,
   // Roster publishing (Phase 2)
   isRosterPublished: true,
+  // Waitlist visibility (pre-publish)
+  showWaitlistBeforePublish: false,
   ...overrides,
 });
 
@@ -513,6 +517,48 @@ describe('eventStore', () => {
       }
 
       expect(useEventStore.getState().processingEventId).toBeNull();
+    });
+  });
+
+  describe('markPayment', () => {
+    it('optimistically sets myPaymentStatus to MarkedPaid on success', async () => {
+      const event = createMockEvent({
+        id: 'event-1',
+        amIWaitlisted: true,
+        myPaymentStatus: 'Pending',
+        myWaitlistPaymentEligible: true,
+      });
+      useEventStore.setState({ events: [event], selectedEvent: event });
+      mockMarkPayment.mockResolvedValue(undefined);
+
+      const result = await useEventStore.getState().markPayment('event-1');
+
+      expect(result).toBe(true);
+      expect(useEventStore.getState().selectedEvent?.myPaymentStatus).toBe('MarkedPaid');
+      expect(useEventStore.getState().events[0].myPaymentStatus).toBe('MarkedPaid');
+    });
+
+    it('rolls back and surfaces server message when rejected (ineligible waitlisted player)', async () => {
+      const serverMessage =
+        "You're on the waitlist and there isn't an open spot for you yet - don't pay yet. The organizer will reach out if a spot opens.";
+      const event = createMockEvent({
+        id: 'event-1',
+        amIWaitlisted: true,
+        myPaymentStatus: 'Pending',
+        myWaitlistPaymentEligible: false,
+      });
+      useEventStore.setState({ events: [event], selectedEvent: event });
+      // The axios interceptor rejects with a plain ApiError object (not an Error instance)
+      mockMarkPayment.mockRejectedValue({ message: serverMessage });
+
+      const result = await useEventStore.getState().markPayment('event-1');
+
+      expect(result).toBe(false);
+      // Rollback to Pending
+      expect(useEventStore.getState().selectedEvent?.myPaymentStatus).toBe('Pending');
+      expect(useEventStore.getState().events[0].myPaymentStatus).toBe('Pending');
+      // Server message surfaced for the UI
+      expect(useEventStore.getState().error).toBe(serverMessage);
     });
   });
 });

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../../components';
 import type { TabKey } from '../../../components';
 import { colors, spacing } from '../../../theme';
-import type { Position } from '@bhmhockey/shared';
+import type { Position, RegistrationResultDto } from '@bhmhockey/shared';
 
 export default function EventDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -113,7 +113,7 @@ export default function EventDetailScreen() {
     }
 
     const showResultMessage = (
-      result: { status: string; waitlistPosition?: number | null; message: string } | null,
+      result: RegistrationResultDto | null,
       position: string
     ) => {
       if (!result) return;

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -289,6 +289,8 @@ export default function EventDetailScreen() {
 
   const spotsLeft = selectedEvent ? selectedEvent.maxPlayers - selectedEvent.registeredCount : 0;
   const isFull = spotsLeft <= 0;
+  // Paid events always waitlist self-registrations until payment is verified
+  const willWaitlist = isFull || (selectedEvent ? selectedEvent.cost > 0 : false);
   const isWaitlisted = selectedEvent?.amIWaitlisted;
   const canManage = selectedEvent?.canManage || false;
 
@@ -377,7 +379,7 @@ export default function EventDetailScreen() {
             isAuthenticated={isAuthenticated}
             isRegistered={selectedEvent.isRegistered}
             isWaitlisted={isWaitlisted || false}
-            isFull={isFull}
+            willWaitlist={willWaitlist}
             isProcessing={isProcessing}
             onRegister={handleRegister}
           />

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -288,9 +288,6 @@ export default function EventDetailScreen() {
   const isFull = spotsLeft <= 0;
   const isWaitlisted = selectedEvent?.amIWaitlisted;
   const canManage = selectedEvent?.canManage || false;
-  // Paid events always waitlist self-registrations until payment is verified —
-  // except event managers, who roster directly (auto-verified) while spots remain
-  const willWaitlist = isFull || (selectedEvent ? selectedEvent.cost > 0 && !canManage : false);
 
   const getOrgAbbreviation = (name: string) => {
     if (!name) return 'Event';
@@ -377,7 +374,7 @@ export default function EventDetailScreen() {
             isAuthenticated={isAuthenticated}
             isRegistered={selectedEvent.isRegistered}
             isWaitlisted={isWaitlisted || false}
-            willWaitlist={willWaitlist}
+            isFull={isFull}
             isProcessing={isProcessing}
             onRegister={handleRegister}
           />

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -119,7 +119,8 @@ export default function EventDetailScreen() {
       if (!result) return;
       if (result.status === 'Waitlisted') {
         // Server message is payment-aware: pay-now vs don't-pay-yet
-        Alert.alert('Added to Waitlist', result.message);
+        const title = result.payEligible ? 'Please Send Payment' : 'Added to Waitlist';
+        Alert.alert(title, result.message);
       } else {
         Alert.alert('Success', `You have been registered as a ${position}!`);
       }

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -289,10 +289,11 @@ export default function EventDetailScreen() {
 
   const spotsLeft = selectedEvent ? selectedEvent.maxPlayers - selectedEvent.registeredCount : 0;
   const isFull = spotsLeft <= 0;
-  // Paid events always waitlist self-registrations until payment is verified
-  const willWaitlist = isFull || (selectedEvent ? selectedEvent.cost > 0 : false);
   const isWaitlisted = selectedEvent?.amIWaitlisted;
   const canManage = selectedEvent?.canManage || false;
+  // Paid events always waitlist self-registrations until payment is verified —
+  // except event managers, who roster directly (auto-verified) while spots remain
+  const willWaitlist = isFull || (selectedEvent ? selectedEvent.cost > 0 && !canManage : false);
 
   const getOrgAbbreviation = (name: string) => {
     if (!name) return 'Event';

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -118,11 +118,8 @@ export default function EventDetailScreen() {
     ) => {
       if (!result) return;
       if (result.status === 'Waitlisted') {
-        // Don't show position during draft mode - roster not yet published
-        Alert.alert(
-          'Added to Waitlist',
-          `You've been added to the waitlist as a ${position}. We'll notify you when a spot opens up!`
-        );
+        // Server message is payment-aware: pay-now vs don't-pay-yet
+        Alert.alert('Added to Waitlist', result.message);
       } else {
         Alert.alert('Success', `You have been registered as a ${position}!`);
       }

--- a/apps/mobile/app/events/create.tsx
+++ b/apps/mobile/app/events/create.tsx
@@ -30,6 +30,7 @@ export default function CreateEventScreen() {
       skillLevels: data.skillLevels,
       applyAutoRoster: data.applyAutoRoster,
       groupMeLink: data.groupMeLink || undefined,
+      showWaitlistBeforePublish: data.showWaitlistBeforePublish,
     });
 
     if (result) {

--- a/apps/mobile/app/events/edit.tsx
+++ b/apps/mobile/app/events/edit.tsx
@@ -53,6 +53,7 @@ export default function EditEventScreen() {
         skillLevels: data.skillLevels,
         // '' clears the event's own link (falls back to org); a value sets the override
         groupMeLink: data.groupMeLink,
+        showWaitlistBeforePublish: data.showWaitlistBeforePublish,
       });
 
       Alert.alert('Success', 'Event updated successfully!', [

--- a/apps/mobile/app/organizations/[id]/settings.tsx
+++ b/apps/mobile/app/organizations/[id]/settings.tsx
@@ -13,6 +13,7 @@ import {
   KeyboardAvoidingView,
   Keyboard,
   InputAccessoryView,
+  Switch,
 } from 'react-native';
 import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
 import { Picker } from '@react-native-picker/picker';
@@ -56,6 +57,7 @@ export default function OrganizationSettingsScreen() {
   const [defaultCost, setDefaultCost] = useState('');
   const [defaultVenue, setDefaultVenue] = useState('');
   const [defaultVisibility, setDefaultVisibility] = useState<EventVisibility | null>(null);
+  const [defaultShowWaitlistBeforePublish, setDefaultShowWaitlistBeforePublish] = useState(false);
   const [groupMeLink, setGroupMeLink] = useState('');
 
   // UI state
@@ -103,6 +105,7 @@ export default function OrganizationSettingsScreen() {
       setDefaultCost(toStr(org.defaultCost));
       setDefaultVenue(org.defaultVenue ?? '');
       setDefaultVisibility(org.defaultVisibility ?? null);
+      setDefaultShowWaitlistBeforePublish(org.defaultShowWaitlistBeforePublish ?? false);
       setGroupMeLink(org.groupMeLink ?? '');
     } catch (error) {
       Alert.alert('Error', 'Failed to load organization');
@@ -201,6 +204,7 @@ export default function OrganizationSettingsScreen() {
         defaultCost: parseFloatOrNull(defaultCost),
         defaultVenue: defaultVenue.trim() || null,
         defaultVisibility,
+        defaultShowWaitlistBeforePublish,
         // '' clears the org's link (backend stores null); a value sets it
         groupMeLink: groupMeLink.trim(),
       });
@@ -412,6 +416,24 @@ export default function OrganizationSettingsScreen() {
             </TouchableOpacity>
           </View>
 
+          {/* Show Waitlist Before Publish */}
+          <View style={styles.field}>
+            <View style={styles.switchRow}>
+              <Text style={styles.switchLabel} allowFontScaling={false}>
+                Show waitlist before publish
+              </Text>
+              <Switch
+                value={defaultShowWaitlistBeforePublish}
+                onValueChange={setDefaultShowWaitlistBeforePublish}
+                trackColor={{ false: colors.bg.hover, true: colors.primary.teal }}
+                thumbColor={defaultShowWaitlistBeforePublish ? colors.text.primary : colors.text.muted}
+              />
+            </View>
+            <Text style={styles.fieldHint} allowFontScaling={false}>
+              New events start with the waitlist visible to registered and waitlisted players before publish
+            </Text>
+          </View>
+
           {/* Save Button */}
           <TouchableOpacity
             style={[styles.saveButton, isSaving && styles.saveButtonDisabled]}
@@ -582,6 +604,22 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.sm,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: colors.bg.elevated,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+  },
+  switchLabel: {
+    fontSize: 15,
+    color: colors.text.primary,
+    flex: 1,
+    marginRight: spacing.sm,
   },
   clearButton: {
     paddingHorizontal: spacing.md,

--- a/apps/mobile/components/EventCard.tsx
+++ b/apps/mobile/components/EventCard.tsx
@@ -157,11 +157,12 @@ function WaitlistedBadges({ event }: { event: EventDto }) {
   const spotsLeft = event.maxPlayers - event.registeredCount;
   const isFull = spotsLeft <= 0;
 
-  // If roster is full, show position (you're actually queued for capacity).
-  // Own position is always visible now, even before the roster is published.
+  // If roster is full, show the full state alongside your position (you're
+  // queued for capacity). Own position is always visible, even pre-publish.
   if (isFull) {
     return (
       <View style={styles.waitlistedStats}>
+        <Badge variant="error">Full</Badge>
         <Badge variant="warning">
           {event.myWaitlistPosition ? `#${event.myWaitlistPosition} on waitlist` : 'Waitlist'}
         </Badge>

--- a/apps/mobile/components/EventCard.tsx
+++ b/apps/mobile/components/EventCard.tsx
@@ -157,12 +157,13 @@ function WaitlistedBadges({ event }: { event: EventDto }) {
   const spotsLeft = event.maxPlayers - event.registeredCount;
   const isFull = spotsLeft <= 0;
 
-  // If roster is full and published, show position (you're actually queued for capacity)
+  // If roster is full, show position (you're actually queued for capacity).
+  // Own position is always visible now, even before the roster is published.
   if (isFull) {
     return (
       <View style={styles.waitlistedStats}>
         <Badge variant="warning">
-          {event.isRosterPublished ? `#${event.myWaitlistPosition} on waitlist` : 'Waitlist'}
+          {event.myWaitlistPosition ? `#${event.myWaitlistPosition} on waitlist` : 'Waitlist'}
         </Badge>
       </View>
     );

--- a/apps/mobile/components/EventCard.tsx
+++ b/apps/mobile/components/EventCard.tsx
@@ -4,7 +4,7 @@ import { Badge } from './Badge';
 import { SkillLevelDots } from './SkillLevelDots';
 import { OrgAvatar } from './OrgAvatar';
 import type { EventDto, SkillLevel } from '@bhmhockey/shared';
-import { getPaymentBadgeInfo } from '../utils/payment';
+import { getSelfPaymentBadgeInfo } from '../utils/payment';
 
 export type EventCardVariant = 'available' | 'registered' | 'waitlisted' | 'organizing';
 
@@ -170,9 +170,21 @@ function WaitlistedBadges({ event }: { event: EventDto }) {
     );
   }
 
-  // Roster has space - you're on waitlist because of payment (pay-to-play model)
-  // Show payment status instead of position
-  const { text, variant } = getPaymentBadgeInfo(event.myPaymentStatus);
+  // Roster has space but people ahead of you hold the open spots - you're
+  // genuinely queued, and shouldn't pay yet
+  if (event.myWaitlistPaymentEligible === false) {
+    return (
+      <View style={styles.waitlistedStats}>
+        <Badge variant="warning">
+          {event.myWaitlistPosition ? `#${event.myWaitlistPosition} on waitlist` : 'Waitlist'}
+        </Badge>
+      </View>
+    );
+  }
+
+  // Roster has space and it's your spot to claim (pay-to-play model):
+  // prompt the action instead of the bare "Unpaid" state
+  const { text, variant } = getSelfPaymentBadgeInfo(event.myPaymentStatus);
   return (
     <View style={styles.waitlistedStats}>
       <Badge variant={variant}>{text}</Badge>
@@ -181,8 +193,9 @@ function WaitlistedBadges({ event }: { event: EventDto }) {
 }
 
 function RegisteredBadges({ event }: { event: EventDto }) {
-  const { text, variant } = getPaymentBadgeInfo(event.myPaymentStatus);
+  const { text, variant } = getSelfPaymentBadgeInfo(event.myPaymentStatus);
   const isBlackTeam = event.myTeamAssignment === 'Black';
+  const needsPayment = event.cost > 0 && event.myPaymentStatus !== 'Verified';
 
   return (
     <View style={styles.registeredStats}>
@@ -200,6 +213,8 @@ function RegisteredBadges({ event }: { event: EventDto }) {
           </Text>
         </View>
       )}
+      {/* Unpaid rostered players see their state + the action: Registered + Send Payment */}
+      {needsPayment && <Badge variant="green">Registered</Badge>}
       {/* Payment badge */}
       {event.cost > 0 && <Badge variant={variant}>{text}</Badge>}
     </View>

--- a/apps/mobile/components/EventForm.tsx
+++ b/apps/mobile/components/EventForm.tsx
@@ -45,6 +45,7 @@ export interface EventFormData {
   skillLevels?: SkillLevel[];
   applyAutoRoster?: boolean;
   groupMeLink?: string;  // '' clears the event's own link (inherits org's); trimmed value sets it
+  showWaitlistBeforePublish: boolean;
 }
 
 interface EventFormProps {
@@ -79,6 +80,7 @@ export function EventForm({
   const [skillLevels, setSkillLevels] = useState<SkillLevel[]>([]);
   const [applyAutoRoster, setApplyAutoRoster] = useState(true);
   const [groupMeLink, setGroupMeLink] = useState('');
+  const [showWaitlistBeforePublish, setShowWaitlistBeforePublish] = useState(false);
 
   // Auto-roster of the selected org (create mode only, admin-only endpoint)
   const autoRoster = useOrganizationStore((state) => state.autoRoster);
@@ -121,6 +123,7 @@ export function EventForm({
       setSkillLevels((initialData.skillLevels as SkillLevel[]) || []);
       // Only pre-fill the event's OWN link - an inherited org link stays blank (blank means inherit)
       setGroupMeLink(initialData.groupMeLinkSource === 'event' ? initialData.groupMeLink || '' : '');
+      setShowWaitlistBeforePublish(initialData.showWaitlistBeforePublish ?? false);
     }
   }, [initialData]);
 
@@ -141,6 +144,7 @@ export function EventForm({
       org.defaultCost,
       org.defaultVenue,
       org.defaultVisibility,
+      org.defaultShowWaitlistBeforePublish,
     ];
     const hasDefaults = defaultFields.some(field => field != null);
     if (!hasDefaults) return;
@@ -199,6 +203,9 @@ export function EventForm({
     if (org.defaultVisibility != null) {
       setVisibility(org.defaultVisibility);
       setVisibilitySelectionMade(true);
+    }
+    if (org.defaultShowWaitlistBeforePublish != null) {
+      setShowWaitlistBeforePublish(org.defaultShowWaitlistBeforePublish);
     }
 
     // Mark defaults as applied and show notification
@@ -348,6 +355,7 @@ export function EventForm({
       skillLevels: skillLevels.length > 0 ? skillLevels : undefined,
       applyAutoRoster: selectedOrgId ? applyAutoRoster : undefined,
       groupMeLink: groupMeLink.trim(),
+      showWaitlistBeforePublish,
     };
 
     await onSubmit(formData);
@@ -589,6 +597,24 @@ export function EventForm({
             </Text>
           </View>
         )}
+
+        {/* Waitlist Visibility Toggle */}
+        <View style={styles.field}>
+          <View style={styles.switchRow}>
+            <Text style={styles.switchLabel} allowFontScaling={false}>
+              Show waitlist before publish
+            </Text>
+            <Switch
+              value={showWaitlistBeforePublish}
+              onValueChange={setShowWaitlistBeforePublish}
+              trackColor={{ false: colors.bg.hover, true: colors.primary.teal }}
+              thumbColor={showWaitlistBeforePublish ? colors.text.primary : colors.text.muted}
+            />
+          </View>
+          <Text style={styles.skillNote}>
+            Registered and waitlisted players can see the waitlist order before the roster is published
+          </Text>
+        </View>
 
         {/* Skill Levels */}
         <View style={styles.field}>

--- a/apps/mobile/components/event-detail/DraftModeRoster.tsx
+++ b/apps/mobile/components/event-detail/DraftModeRoster.tsx
@@ -1,19 +1,26 @@
 import { View, Text, StyleSheet } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import type { EventDto } from '@bhmhockey/shared';
+import type { EventDto, EventRegistrationDto } from '@bhmhockey/shared';
 import { colors, spacing, radius } from '../../theme';
 import { Badge } from '../Badge';
 import { getPaymentBadgeInfo } from '../../utils/payment';
 
 interface DraftModeRosterProps {
   event: EventDto;
+  /** Pre-publish waitlist (server returns it only when showWaitlistBeforePublish allows the viewer) */
+  waitlist?: EventRegistrationDto[];
 }
 
-export function DraftModeRoster({ event }: DraftModeRosterProps) {
+export function DraftModeRoster({ event, waitlist = [] }: DraftModeRosterProps) {
   const isRegistered = event.isRegistered;
   const isWaitlisted = event.amIWaitlisted;
   const paymentStatus = event.myPaymentStatus;
   const isPaidEvent = event.cost > 0;
+
+  // Server only returns the pre-publish waitlist to registered/waitlisted viewers when the
+  // event setting is on - this client check just mirrors that gate
+  const showWaitlist =
+    event.showWaitlistBeforePublish && (isRegistered || isWaitlisted) && waitlist.length > 0;
 
   return (
     <View style={styles.container}>
@@ -61,7 +68,9 @@ export function DraftModeRoster({ event }: DraftModeRosterProps) {
             </Text>
           </View>
           <Text style={styles.confirmationSubtext} allowFontScaling={false}>
-            Your exact position will be visible when the roster is published.
+            {event.myWaitlistPosition
+              ? `You're #${event.myWaitlistPosition} of ${event.waitlistCount} on the waitlist.`
+              : "You're on the waitlist."}
           </Text>
           {isPaidEvent && paymentStatus && (
             <View style={styles.paymentRow}>
@@ -78,6 +87,32 @@ export function DraftModeRoster({ event }: DraftModeRosterProps) {
           <Text style={styles.notRegisteredText} allowFontScaling={false}>
             You're not registered for this event.
           </Text>
+        </View>
+      )}
+
+      {/* Pre-publish Waitlist (names + positions only - no payment info) */}
+      {showWaitlist && (
+        <View style={styles.waitlistCard}>
+          <Text style={styles.waitlistTitle} allowFontScaling={false}>
+            Waitlist ({waitlist.length})
+          </Text>
+          {waitlist.map((registration, index) => (
+            <View key={registration.id} style={styles.waitlistRow}>
+              <View style={styles.waitlistPositionBadge}>
+                <Text style={styles.waitlistPositionText} allowFontScaling={false}>
+                  #{registration.waitlistPosition ?? index + 1}
+                </Text>
+              </View>
+              <View style={styles.waitlistUserInfo}>
+                <Text style={styles.waitlistUserName} allowFontScaling={false}>
+                  {registration.user.firstName} {registration.user.lastName}
+                </Text>
+                <Text style={styles.waitlistUserMeta} allowFontScaling={false}>
+                  {registration.registeredPosition || 'Skater'}
+                </Text>
+              </View>
+            </View>
+          ))}
         </View>
       )}
     </View>
@@ -157,5 +192,53 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: colors.text.secondary,
     textAlign: 'center',
+  },
+  waitlistCard: {
+    backgroundColor: colors.bg.dark,
+    borderRadius: radius.lg,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    marginTop: spacing.lg,
+  },
+  waitlistTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.text.primary,
+    marginBottom: spacing.sm,
+  },
+  waitlistRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.default,
+  },
+  waitlistPositionBadge: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: colors.status.warningSubtle,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: spacing.sm,
+  },
+  waitlistPositionText: {
+    color: colors.status.warning,
+    fontWeight: '700',
+    fontSize: 12,
+  },
+  waitlistUserInfo: {
+    flex: 1,
+  },
+  waitlistUserName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.text.primary,
+  },
+  waitlistUserMeta: {
+    fontSize: 13,
+    color: colors.text.muted,
+    marginTop: 2,
   },
 });

--- a/apps/mobile/components/event-detail/DraftModeRoster.tsx
+++ b/apps/mobile/components/event-detail/DraftModeRoster.tsx
@@ -3,7 +3,7 @@ import { Ionicons } from '@expo/vector-icons';
 import type { EventDto, EventRegistrationDto } from '@bhmhockey/shared';
 import { colors, spacing, radius } from '../../theme';
 import { Badge } from '../Badge';
-import { getPaymentBadgeInfo } from '../../utils/payment';
+import { getSelfPaymentBadgeInfo } from '../../utils/payment';
 
 interface DraftModeRosterProps {
   event: EventDto;
@@ -46,13 +46,14 @@ export function DraftModeRoster({ event, waitlist = [] }: DraftModeRosterProps) 
             </Text>
           </View>
           <Text style={styles.confirmationSubtext} allowFontScaling={false}>
-            Your spot is confirmed. Team assignment will be visible when the
-            roster is published.
+            {paymentStatus === 'Pending'
+              ? 'Your spot is confirmed - please send your payment. Team assignment will be visible when the roster is published.'
+              : 'Your spot is confirmed. Team assignment will be visible when the roster is published.'}
           </Text>
           {isPaidEvent && paymentStatus && (
             <View style={styles.paymentRow}>
-              <Badge variant={getPaymentBadgeInfo(paymentStatus).variant}>
-                {getPaymentBadgeInfo(paymentStatus).text}
+              <Badge variant={getSelfPaymentBadgeInfo(paymentStatus).variant}>
+                {getSelfPaymentBadgeInfo(paymentStatus).text}
               </Badge>
             </View>
           )}
@@ -68,14 +69,25 @@ export function DraftModeRoster({ event, waitlist = [] }: DraftModeRosterProps) 
             </Text>
           </View>
           <Text style={styles.confirmationSubtext} allowFontScaling={false}>
-            {event.myWaitlistPosition
-              ? `You're #${event.myWaitlistPosition} of ${event.waitlistCount} on the waitlist.`
-              : "You're on the waitlist."}
+            {(() => {
+              const position = event.myWaitlistPosition
+                ? `You're #${event.myWaitlistPosition} of ${event.waitlistCount} on the waitlist.`
+                : "You're on the waitlist.";
+              // Mirror the registration popup: pay now when a spot is
+              // claimable, hold off when genuinely queued
+              if (event.myWaitlistPaymentEligible === true) {
+                return `${position} Send your payment to secure your spot - the event is not yet full.`;
+              }
+              if (event.myWaitlistPaymentEligible === false) {
+                return `${position} Don't pay yet - the organizer will reach out if a spot opens.`;
+              }
+              return position;
+            })()}
           </Text>
-          {isPaidEvent && paymentStatus && (
+          {isPaidEvent && paymentStatus && event.myWaitlistPaymentEligible !== false && (
             <View style={styles.paymentRow}>
-              <Badge variant={getPaymentBadgeInfo(paymentStatus).variant}>
-                {getPaymentBadgeInfo(paymentStatus).text}
+              <Badge variant={getSelfPaymentBadgeInfo(paymentStatus).variant}>
+                {getSelfPaymentBadgeInfo(paymentStatus).text}
               </Badge>
             </View>
           )}

--- a/apps/mobile/components/event-detail/EventInfoTab.tsx
+++ b/apps/mobile/components/event-detail/EventInfoTab.tsx
@@ -30,6 +30,9 @@ export function EventInfoTab({
   const showCostPreview = !event.isRegistered && !event.amIWaitlisted && event.cost > 0;
   const hasMoreDetails = event.description || event.registrationDeadline;
   const isRosterFull = event.registeredCount >= event.maxPlayers;
+  // Waitlisted players should only pay when their spot fits open capacity (server-computed).
+  // Only an explicit false hides the pay affordance - null/undefined keeps it available.
+  const waitlistPayIneligible = event.myWaitlistPaymentEligible === false;
 
   // Format: "SAT"
   const getDayName = (dateString: string) => {
@@ -122,7 +125,7 @@ export function EventInfoTab({
             {event.isRegistered && <Badge variant="green">Registered</Badge>}
             {event.amIWaitlisted && (
               <Badge variant="warning">
-                {event.isRosterPublished ? `#${event.myWaitlistPosition} Waitlist` : 'Waitlist'}
+                {event.myWaitlistPosition ? `#${event.myWaitlistPosition} Waitlist` : 'Waitlist'}
               </Badge>
             )}
             {/* Payment status badge for registered/waitlisted users on paid events */}
@@ -149,22 +152,28 @@ export function EventInfoTab({
             <View style={styles.paymentDivider} />
 
             <View style={styles.waitlistPaymentSection}>
-              {/* Waitlist Position Header - only show when roster is full AND published */}
-              {isRosterFull && event.isRosterPublished && (
+              {/* Waitlist Position Header - own position is always visible now.
+                  Skipped for ineligible pending payments (their message includes it). */}
+              {event.myWaitlistPosition != null &&
+                !(event.myPaymentStatus === 'Pending' && waitlistPayIneligible) && (
                 <Text style={styles.waitlistPositionText}>
-                  You're #{event.myWaitlistPosition} on the waitlist
+                  You're #{event.myWaitlistPosition} of {event.waitlistCount} on the waitlist
                 </Text>
               )}
 
-              {/* Pending: Show payment prompt and buttons */}
-              {event.myPaymentStatus === 'Pending' && (
+              {/* Pending + ineligible: no pay affordance - the spot doesn't fit open capacity */}
+              {event.myPaymentStatus === 'Pending' && waitlistPayIneligible && (
+                <Text style={styles.waitlistPaymentPrompt}>
+                  You're #{event.myWaitlistPosition} of {event.waitlistCount} on the waitlist — don't
+                  pay yet. The organizer will reach out if a spot opens.
+                </Text>
+              )}
+
+              {/* Pending + eligible: prompt to pay and claim the spot */}
+              {event.myPaymentStatus === 'Pending' && !waitlistPayIneligible && (
                 <>
                   <Text style={styles.waitlistPaymentPrompt}>
-                    {!event.isRosterPublished
-                      ? 'Pay to secure your registration'
-                      : isRosterFull
-                        ? 'Pay to be ready when a spot opens'
-                        : 'Pay to secure your spot on the roster'}
+                    Send ${event.cost.toFixed(2)} to claim your spot
                   </Text>
 
                   <View style={styles.paymentActions}>

--- a/apps/mobile/components/event-detail/EventRosterTab.tsx
+++ b/apps/mobile/components/event-detail/EventRosterTab.tsx
@@ -543,9 +543,11 @@ export function EventRosterTab({ eventId, event, canManage }: EventRosterTabProp
     );
   }
 
-  // Draft mode: non-organizers see simplified view without roster details
+  // Draft mode: non-organizers see simplified view without roster details.
+  // When showWaitlistBeforePublish allows it, the server returns waitlisted entries
+  // (payment info stripped) for registered/waitlisted viewers - pass them through.
   if (!event.isRosterPublished && !canManage) {
-    return <DraftModeRoster event={event} />;
+    return <DraftModeRoster event={event} waitlist={waitlist} />;
   }
 
   const showPayment = canManage;

--- a/apps/mobile/components/event-detail/RegistrationFooter.tsx
+++ b/apps/mobile/components/event-detail/RegistrationFooter.tsx
@@ -6,9 +6,11 @@ interface RegistrationFooterProps {
   isAuthenticated: boolean;
   isRegistered: boolean;
   isWaitlisted: boolean;
-  // True when registering would place the user on the waitlist (paid events
-  // always waitlist first; free events waitlist once skater spots are full)
-  willWaitlist: boolean;
+  // Full = yellow "Join Waitlist"; otherwise teal "Register for Event".
+  // On paid events registration technically waitlists until payment is
+  // verified, but with open spots the register popup and info tab carry
+  // the "send payment to secure your spot" guidance.
+  isFull: boolean;
   isProcessing: boolean;
   onRegister: () => void;
 }
@@ -17,7 +19,7 @@ export function RegistrationFooter({
   isAuthenticated,
   isRegistered,
   isWaitlisted,
-  willWaitlist,
+  isFull,
   isProcessing,
   onRegister,
 }: RegistrationFooterProps) {
@@ -39,8 +41,8 @@ export function RegistrationFooter({
     return null;
   }
 
-  // Registration would land on the waitlist - say so
-  if (willWaitlist) {
+  // Event full - joining means the waitlist, say so
+  if (isFull) {
     return (
       <View style={[styles.container, { paddingBottom: Math.max(insets.bottom, spacing.md) }]}>
         <TouchableOpacity

--- a/apps/mobile/components/event-detail/RegistrationFooter.tsx
+++ b/apps/mobile/components/event-detail/RegistrationFooter.tsx
@@ -6,7 +6,9 @@ interface RegistrationFooterProps {
   isAuthenticated: boolean;
   isRegistered: boolean;
   isWaitlisted: boolean;
-  isFull: boolean;
+  // True when registering would place the user on the waitlist (paid events
+  // always waitlist first; free events waitlist once skater spots are full)
+  willWaitlist: boolean;
   isProcessing: boolean;
   onRegister: () => void;
 }
@@ -15,7 +17,7 @@ export function RegistrationFooter({
   isAuthenticated,
   isRegistered,
   isWaitlisted,
-  isFull,
+  willWaitlist,
   isProcessing,
   onRegister,
 }: RegistrationFooterProps) {
@@ -37,8 +39,8 @@ export function RegistrationFooter({
     return null;
   }
 
-  // Event full - show join waitlist
-  if (isFull) {
+  // Registration would land on the waitlist - say so
+  if (willWaitlist) {
     return (
       <View style={[styles.container, { paddingBottom: Math.max(insets.bottom, spacing.md) }]}>
         <TouchableOpacity

--- a/apps/mobile/stores/eventStore.ts
+++ b/apps/mobile/stores/eventStore.ts
@@ -151,16 +151,22 @@ export const useEventStore = create<EventState>((set, get) => ({
       myPaymentStatus: event.cost > 0 ? 'Pending' : undefined,
       amIWaitlisted: false,
       myWaitlistPosition: undefined,
+      myWaitlistPaymentEligible: null,
     });
 
     // Helper to update event for waitlisted status
-    const updateEventAsWaitlisted = (event: EventDto, waitlistPosition: number): EventDto => ({
+    const updateEventAsWaitlisted = (
+      event: EventDto,
+      waitlistPosition: number,
+      payEligible?: boolean | null
+    ): EventDto => ({
       ...event,
       isRegistered: false,
       amIWaitlisted: true,
       myWaitlistPosition: waitlistPosition,
       myPaymentStatus: 'Pending' as PaymentStatus,
       waitlistCount: event.waitlistCount + 1,
+      myWaitlistPaymentEligible: payEligible ?? null,
     });
 
     // Only do optimistic update if there's room
@@ -197,10 +203,10 @@ export const useEventStore = create<EventState>((set, get) => ({
         const waitlistPosition = result.waitlistPosition ?? 1;
         const waitlistedEvent = events.find(e => e.id === eventId);
         if (waitlistedEvent) {
-          const updatedEvent = updateEventAsWaitlisted(waitlistedEvent, waitlistPosition);
+          const updatedEvent = updateEventAsWaitlisted(waitlistedEvent, waitlistPosition, result.payEligible);
           set({
             events: events.map(e => e.id === eventId ? updatedEvent : e),
-            selectedEvent: selectedEvent?.id === eventId ? updateEventAsWaitlisted(selectedEvent, waitlistPosition) : selectedEvent,
+            selectedEvent: selectedEvent?.id === eventId ? updateEventAsWaitlisted(selectedEvent, waitlistPosition, result.payEligible) : selectedEvent,
             myRegistrations: [...myRegistrations, updatedEvent],
             processingEventId: null,
           });

--- a/apps/mobile/utils/payment.ts
+++ b/apps/mobile/utils/payment.ts
@@ -24,3 +24,13 @@ export function getPaymentBadgeInfo(status?: PaymentStatus | null): PaymentBadge
       return { text: 'Unpaid', variant: 'error' };
   }
 }
+
+/**
+ * Same mapping, but addressed to the viewer about their OWN registration:
+ * "Unpaid" becomes the action prompt "Send Payment". Organizer views of
+ * other players keep getPaymentBadgeInfo's "Unpaid".
+ */
+export function getSelfPaymentBadgeInfo(status?: PaymentStatus | null): PaymentBadgeInfo {
+  const info = getPaymentBadgeInfo(status);
+  return info.text === 'Unpaid' ? { text: 'Send Payment', variant: 'error' } : info;
+}

--- a/packages/api-client/__tests__/services/events.test.ts
+++ b/packages/api-client/__tests__/services/events.test.ts
@@ -1,0 +1,98 @@
+/**
+ * EventService Tests - Verifying the API client passes the waitlist-visibility
+ * setting and payment calls through to the correct endpoints.
+ */
+
+// Mock AsyncStorage before any imports
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn(() => Promise.resolve()),
+  getItem: jest.fn(() => Promise.resolve(null)),
+  removeItem: jest.fn(() => Promise.resolve()),
+}));
+
+// Store axios mock functions
+const mockPost = jest.fn();
+const mockGet = jest.fn();
+const mockPut = jest.fn();
+const mockDelete = jest.fn();
+
+// Mock axios
+jest.mock('axios', () => ({
+  create: jest.fn(() => ({
+    interceptors: {
+      request: { use: jest.fn() },
+      response: { use: jest.fn() },
+    },
+    post: mockPost,
+    get: mockGet,
+    put: mockPut,
+    delete: mockDelete,
+  })),
+}));
+
+// Import after mocking
+import { eventService } from '../../src/services/events';
+import { initializeApiClient } from '../../src/client';
+
+describe('eventService waitlist visibility & payment', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    initializeApiClient({ baseURL: 'http://localhost:5001/api' });
+  });
+
+  describe('create', () => {
+    it('passes showWaitlistBeforePublish through to the create endpoint', async () => {
+      const request = {
+        eventDate: '2026-08-01T00:00:00Z',
+        maxPlayers: 12,
+        cost: 25,
+        showWaitlistBeforePublish: true,
+      };
+      mockPost.mockResolvedValueOnce({ data: { id: 'event-1' } });
+
+      await eventService.create(request);
+
+      expect(mockPost).toHaveBeenCalledWith('/events', request);
+    });
+  });
+
+  describe('update', () => {
+    it('passes showWaitlistBeforePublish through to the update endpoint', async () => {
+      mockPut.mockResolvedValueOnce({ data: { id: 'event-1' } });
+
+      await eventService.update('event-1', { showWaitlistBeforePublish: false });
+
+      expect(mockPut).toHaveBeenCalledWith('/events/event-1', {
+        showWaitlistBeforePublish: false,
+      });
+    });
+  });
+
+  describe('markPayment', () => {
+    it('posts to the mark-paid endpoint', async () => {
+      mockPost.mockResolvedValueOnce({ data: {} });
+
+      await eventService.markPayment('event-1');
+
+      expect(mockPost).toHaveBeenCalledWith('/events/event-1/payment/mark-paid', {});
+    });
+
+    it('surfaces server rejection (ineligible waitlisted player)', async () => {
+      const apiError = { message: "You're on the waitlist and there isn't an open spot for you yet - don't pay yet. The organizer will reach out if a spot opens." };
+      mockPost.mockRejectedValueOnce(apiError);
+
+      await expect(eventService.markPayment('event-1')).rejects.toEqual(apiError);
+    });
+  });
+
+  describe('getRegistrations', () => {
+    it('fetches registrations from the correct endpoint', async () => {
+      mockGet.mockResolvedValueOnce({ data: [] });
+
+      const result = await eventService.getRegistrations('event-1');
+
+      expect(mockGet).toHaveBeenCalledWith('/events/event-1/registrations');
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -57,6 +57,7 @@ export interface Organization {
   defaultCost?: number | null;
   defaultVenue?: string | null;
   defaultVisibility?: EventVisibility | null;
+  defaultShowWaitlistBeforePublish?: boolean | null;  // Pre-fills showWaitlistBeforePublish on new events
   groupMeLink?: string | null;  // Org-wide GroupMe chat link (events fall back to this)
 }
 
@@ -133,6 +134,7 @@ export interface CreateOrganizationRequest {
   defaultCost?: number | null;
   defaultVenue?: string | null;
   defaultVisibility?: EventVisibility | null;
+  defaultShowWaitlistBeforePublish?: boolean | null;
   groupMeLink?: string | null;  // Org-wide GroupMe chat link
 }
 
@@ -149,6 +151,7 @@ export interface UpdateOrganizationRequest {
   defaultCost?: number | null;
   defaultVenue?: string | null;
   defaultVisibility?: EventVisibility | null;
+  defaultShowWaitlistBeforePublish?: boolean | null;  // null/undefined leaves it unchanged
   groupMeLink?: string | null;  // Empty/whitespace clears the link; null/undefined leaves it unchanged
 }
 
@@ -234,9 +237,13 @@ export interface EventDto {
   unpaidCount?: number;          // Count of registrations with PaymentStatus != "Verified"
   // Waitlist fields (Phase 5)
   waitlistCount: number;         // Number of people on waitlist
-  myWaitlistPosition?: number;   // Current user's waitlist position (null if not waitlisted)
+  myWaitlistPosition?: number;   // Current user's waitlist position (null if not waitlisted); always visible to the player
   myPaymentDeadline?: string;    // Current user's payment deadline after promotion (ISO date string)
   amIWaitlisted: boolean;        // Convenience flag - true if current user is on waitlist
+  // Waitlist visibility (pre-publish)
+  showWaitlistBeforePublish: boolean;  // Registered/waitlisted viewers can see the ordered waitlist before publish
+  // Pay-eligibility for the current user's waitlisted registration on paid events
+  myWaitlistPaymentEligible?: boolean | null;  // null when not applicable (not waitlisted or free event)
   // Slot position labels (organizer feature)
   slotPositionLabels?: Record<number, string>; // Maps slot index to position label (e.g., {1: "C", 2: "LW"})
   // GroupMe chat link, resolved server-side at read time: event override wins, else org's link
@@ -283,6 +290,7 @@ export interface CreateEventRequest {
   skillLevels?: SkillLevel[];    // Optional - overrides org's skill levels if set
   applyAutoRoster?: boolean;     // Auto-add the org's auto-roster members (default true; ignored for standalone events)
   groupMeLink?: string;          // Optional game-specific GroupMe link (blank inherits org's link)
+  showWaitlistBeforePublish?: boolean;  // Optional - defaults to false (form pre-fills from org default)
 }
 
 export interface UpdateEventRequest {
@@ -299,6 +307,7 @@ export interface UpdateEventRequest {
   skillLevels?: SkillLevel[];    // Can change skill levels after creation
   slotPositionLabels?: Record<number, string>;  // Slot position labels (e.g., {1: "C", 2: "LW"})
   groupMeLink?: string;          // Empty string clears the override (falls back to org); undefined leaves unchanged
+  showWaitlistBeforePublish?: boolean;  // undefined leaves unchanged
 }
 
 // Payment request types (Phase 4)

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -200,6 +200,8 @@ export interface RegistrationResultDto {
   status: 'Registered' | 'Waitlisted';
   waitlistPosition: number | null;
   message: string;
+  /** Waitlisted on a paid event: may they pay now? (null/undefined otherwise) */
+  payEligible?: boolean | null;
 }
 
 // Team assignment for events


### PR DESCRIPTION
## Summary

Two bundled player-experience improvements for the waitlist, shaped around the organizer's manual verify-and-promote workflow:

1. **Waitlist visibility setting** — new `ShowWaitlistBeforePublish` on events (org default `DefaultShowWaitlistBeforePublish` pre-fills the create form like other Event Defaults). When on and the roster is unpublished, registered/waitlisted viewers see the ordered waitlist (names + position, no payment info). Roster names stay hidden until publish. Server-enforced by viewer identity.
2. **Payment guidance** — a waitlisted player's own "#X of Y" is now always visible, and on paid events every surface tells them exactly one of two things, driven by a single capacity-based eligibility rule (rank fits open spots; goalies always eligible since they don't consume MaxPlayers):
   - **Pay now**: "Please Send Payment" popup, "Send Payment" badges, "send your payment to secure your spot" copy
   - **Don't pay yet**: "the organizer will reach out if a spot opens" — enforced server-side (MarkPayment → 400 for ineligible waitlisted players)

## Also in this PR (from manual testing rounds)

- Event managers self-registering with an open spot roster directly as payment-Verified (no more verifying your own payment); when full they waitlist normally
- Yellow "Join Waitlist" button only on genuinely full events; teal Register otherwise
- Registration popup title/copy distinguishes pay-now from queued; result carries `PayEligible` so the info tab is correct immediately (no stale optimistic state)
- Event cards: "Full" + "#N on waitlist" badges show together; self-view "Send Payment" replaces bare "Unpaid" (organizer views of others unchanged); rostered-unpaid shows "Registered" + "Send Payment"
- Roster-tab draft cards carry the same eligibility-aware guidance

## Explicitly unchanged

Cancellation, verified-first promotion, and organizer manual add/remove/verify flows. The old "spot available" notification blast to unverified waitlisted players is **removed** (organizer handles all outreach manually; `NotificationType.SpotAvailable` deleted). No other notifications added or changed.

## Testing

- API suite: 960 → 991 (eligibility math incl. goalie/boundary cases, MarkPayment enforcement, own-position ungating, waitlist gating by viewer+setting+publish state, manager self-registration, message copy, spot-blast removal, promotion regression sanity)
- Frontend: shared 41, api-client 31 (+5), mobile 87 (+2); mobile type-check clean
- Live E2E verified against a throwaway org (7 scenarios incl. no-notification check and verified-promotion sanity), cleaned up afterward
- Extensive manual simulator testing by @auc0le across organizer and player accounts (10 refinements folded in from that testing)

Additive-only migration (2 columns). DTOs mirrored in `@bhmhockey/shared`. No `UserDto` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)