### PR TITLE
Add in-place guest player editing for organizers

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Controllers/EventsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/EventsControllerTests.cs
@@ -855,4 +855,98 @@ public class EventsControllerTests
     }
 
     #endregion
+
+    #region UpdateGhostPlayer Tests
+
+    private EventRegistrationDto CreateGhostRegistrationDto(Guid ghostUserId)
+    {
+        return new EventRegistrationDto(
+            Id: Guid.NewGuid(),
+            EventId: _testEventId,
+            User: new UserDto(
+                Id: ghostUserId,
+                Email: "ghost_abc@placeholder.bhmhockey",
+                FirstName: "Jane",
+                LastName: "Smith",
+                PhoneNumber: null,
+                Positions: new Dictionary<string, string> { { "skater", "Silver" } },
+                VenmoHandle: null,
+                Role: "Player",
+                CreatedAt: DateTime.UtcNow,
+                Badges: null,
+                TotalBadgeCount: 0,
+                IsGhostPlayer: true),
+            Status: "Registered",
+            RegisteredAt: DateTime.UtcNow,
+            RegisteredPosition: "Skater",
+            PaymentStatus: null,
+            PaymentMarkedAt: null,
+            PaymentVerifiedAt: null,
+            TeamAssignment: "Black",
+            RosterOrder: null,
+            WaitlistPosition: null,
+            PromotedAt: null,
+            PaymentDeadlineAt: null,
+            IsWaitlisted: false);
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayer_AsOrganizer_ReturnsOkWithRegistration()
+    {
+        // Arrange
+        SetupAuthenticatedUser();
+        var ghostUserId = Guid.NewGuid();
+        var request = new UpdateGhostPlayerRequest("Jane", "Smith", "Skater", "Silver");
+        var updated = CreateGhostRegistrationDto(ghostUserId);
+        _mockEventService.Setup(s => s.UpdateGhostPlayerAsync(
+                _testEventId, _testUserId, ghostUserId, "Jane", "Smith", "Skater", "Silver"))
+            .ReturnsAsync(updated);
+
+        // Act
+        var result = await _controller.UpdateGhostPlayer(_testEventId, ghostUserId, request);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().Be(updated);
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayer_BusinessRuleViolation_Returns400WithMessage()
+    {
+        // Arrange - e.g. roster full for skaters on a Goalie -> Skater change
+        SetupAuthenticatedUser();
+        var ghostUserId = Guid.NewGuid();
+        var request = new UpdateGhostPlayerRequest("Jane", "Smith", "Skater", null);
+        var message = "The roster is full for skaters. Free up a skater spot before switching this guest from Goalie to Skater.";
+        _mockEventService.Setup(s => s.UpdateGhostPlayerAsync(
+                _testEventId, _testUserId, ghostUserId, "Jane", "Smith", "Skater", null))
+            .ThrowsAsync(new InvalidOperationException(message));
+
+        // Act
+        var result = await _controller.UpdateGhostPlayer(_testEventId, ghostUserId, request);
+
+        // Assert
+        var badRequest = result.Result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value!.ToString().Should().Contain("full for skaters");
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayer_AsNonManager_ReturnsForbid()
+    {
+        // Arrange
+        SetupAuthenticatedUser();
+        var ghostUserId = Guid.NewGuid();
+        var request = new UpdateGhostPlayerRequest("Jane", "Smith", "Skater", null);
+        _mockEventService.Setup(s => s.UpdateGhostPlayerAsync(
+                _testEventId, _testUserId, ghostUserId, "Jane", "Smith", "Skater", null))
+            .ThrowsAsync(new UnauthorizedAccessException("You don't have permission to manage this event"));
+
+        // Act
+        var result = await _controller.UpdateGhostPlayer(_testEventId, ghostUserId, request);
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    #endregion
 }

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -3583,6 +3583,279 @@ public class EventServiceTests : IDisposable
 
     #endregion
 
+    #region UpdateGhostPlayerAsync Tests (Guest Player Editing)
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_NameOnlyChange_UpdatesNameWithoutTouchingRegistration()
+    {
+        // Arrange
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 25);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", "Silver");
+
+        // Act - change name only (position and skill unchanged)
+        var result = await _sut.UpdateGhostPlayerAsync(
+            evt.Id, organizer.Id, created.User.Id, "Jane", "Smith", "Skater", "Silver");
+
+        // Assert - name updated, everything else untouched, same registration (spot never released)
+        result.Id.Should().Be(created.Id);
+        result.User.FirstName.Should().Be("Jane");
+        result.User.LastName.Should().Be("Smith");
+        result.RegisteredPosition.Should().Be("Skater");
+        result.TeamAssignment.Should().Be(created.TeamAssignment);
+        result.PaymentStatus.Should().Be(created.PaymentStatus);
+        result.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_NonOrganizer_ThrowsUnauthorized()
+    {
+        // Arrange
+        var organizer = await CreateTestUser("organizer@example.com");
+        var nonOrganizer = await CreateTestUser("random@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(
+            () => _sut.UpdateGhostPlayerAsync(
+                evt.Id, nonOrganizer.Id, created.User.Id, "Jane", "Smith", "Skater", null)
+        );
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_RealUser_ThrowsInvalidOperation()
+    {
+        // Arrange
+        var organizer = await CreateTestUser("organizer@example.com");
+        var realPlayer = await CreateTestUser("real@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        await CreateRegistration(evt.Id, realPlayer.Id, "Registered");
+
+        // Act & Assert - real accounts cannot be edited through the ghost endpoint
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.UpdateGhostPlayerAsync(
+                evt.Id, organizer.Id, realPlayer.Id, "Jane", "Smith", "Skater", null)
+        );
+        ex.Message.Should().Contain("guest players");
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_NoActiveRegistration_ThrowsInvalidOperation()
+    {
+        // Arrange - ghost exists but is registered on a different event
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt1 = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var evt2 = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt1.Id, organizer.Id, "John", "Doe", "Skater", null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.UpdateGhostPlayerAsync(
+                evt2.Id, organizer.Id, created.User.Id, "Jane", "Smith", "Skater", null)
+        );
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_InvalidPosition_ThrowsException()
+    {
+        // Arrange
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.UpdateGhostPlayerAsync(
+                evt.Id, organizer.Id, created.User.Id, "John", "Doe", "InvalidPosition", null)
+        );
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_InvalidSkillLevel_ThrowsException()
+    {
+        // Arrange
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.UpdateGhostPlayerAsync(
+                evt.Id, organizer.Id, created.User.Id, "John", "Doe", "Skater", "InvalidLevel")
+        );
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_SkaterToGoalie_AlwaysAllowed_ReassignsTeam()
+    {
+        // Arrange - full roster (skater spots all taken)
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 1, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", null);
+
+        // Act - Skater -> Goalie frees a skater spot; always allowed even when roster is full
+        var result = await _sut.UpdateGhostPlayerAsync(
+            evt.Id, organizer.Id, created.User.Id, "John", "Doe", "Goalie", null);
+
+        // Assert
+        result.Id.Should().Be(created.Id);
+        result.RegisteredPosition.Should().Be("Goalie");
+        result.Status.Should().Be("Registered");
+        result.TeamAssignment.Should().NotBeNull();  // Recomputed by the balancer
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_GoalieToSkater_RosterFull_ThrowsInvalidOperation()
+    {
+        // Arrange - goalie ghost plus a full skater roster
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 1, cost: 0);
+        var ghostGoalie = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "Ghost", "Goalie", "Goalie", null);
+        var ghostSkater = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "Ghost", "Skater", "Skater", null);
+        ghostSkater.Status.Should().Be("Registered");  // Sanity: skater roster now full
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _sut.UpdateGhostPlayerAsync(
+                evt.Id, organizer.Id, ghostGoalie.User.Id, "Ghost", "Goalie", "Skater", null)
+        );
+        ex.Message.Should().Contain("full");
+
+        // Registration unchanged after the failed edit
+        var registration = await _context.EventRegistrations
+            .FirstAsync(r => r.Id == ghostGoalie.Id);
+        registration.RegisteredPosition.Should().Be("Goalie");
+        registration.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_GoalieToSkater_WithSpace_Succeeds()
+    {
+        // Arrange
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Goalie", null);
+
+        // Act
+        var result = await _sut.UpdateGhostPlayerAsync(
+            evt.Id, organizer.Id, created.User.Id, "John", "Doe", "Skater", null);
+
+        // Assert
+        result.Id.Should().Be(created.Id);
+        result.RegisteredPosition.Should().Be("Skater");
+        result.Status.Should().Be("Registered");
+        result.TeamAssignment.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_PositionChange_RecomputesTeamViaBalancer()
+    {
+        // Arrange - Black already has a goalie, so a new goalie should balance to White
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+
+        var existingGoalie = await CreateTestUser("goalie@example.com");
+        var goalieReg = await CreateRegistration(evt.Id, existingGoalie.Id, "Registered");
+        goalieReg.RegisteredPosition = "Goalie";
+        goalieReg.TeamAssignment = "Black";
+        await _context.SaveChangesAsync();
+
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", null);
+
+        // Act - Skater -> Goalie
+        var result = await _sut.UpdateGhostPlayerAsync(
+            evt.Id, organizer.Id, created.User.Id, "John", "Doe", "Goalie", null);
+
+        // Assert - balancer puts the second goalie on White
+        result.TeamAssignment.Should().Be("White");
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_NameOnlyChange_DoesNotRecomputeTeam()
+    {
+        // Arrange - put the ghost on White, which the balancer would not pick (Black has fewer skaters)
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", null);
+
+        var registration = await _context.EventRegistrations.FirstAsync(r => r.Id == created.Id);
+        registration.TeamAssignment = "White";
+        await _context.SaveChangesAsync();
+
+        // Act - name-only edit
+        var result = await _sut.UpdateGhostPlayerAsync(
+            evt.Id, organizer.Id, created.User.Id, "Jane", "Smith", "Skater", null);
+
+        // Assert - team untouched (balancer would have chosen Black)
+        result.TeamAssignment.Should().Be("White");
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_WaitlistedGhost_UpdatesFields_KeepsWaitlistPosition()
+    {
+        // Arrange - roster full, ghost lands on waitlist
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 1, cost: 0);
+
+        var existingPlayer = await CreateTestUser("existing@example.com");
+        var existingReg = await CreateRegistration(evt.Id, existingPlayer.Id, "Registered");
+        existingReg.TeamAssignment = "Black";
+        await _context.SaveChangesAsync();
+
+        _mockWaitlistService.Setup(w => w.GetNextWaitlistPositionAsync(evt.Id))
+            .ReturnsAsync(1);
+
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", null);
+        created.Status.Should().Be("Waitlisted");
+
+        // Act - edit name, skill, and position (Skater -> Goalie) while waitlisted
+        var result = await _sut.UpdateGhostPlayerAsync(
+            evt.Id, organizer.Id, created.User.Id, "Jane", "Smith", "Goalie", "Gold");
+
+        // Assert - fields updated; waitlist position untouched, no team assigned
+        result.Id.Should().Be(created.Id);
+        result.User.FirstName.Should().Be("Jane");
+        result.RegisteredPosition.Should().Be("Goalie");
+        result.Status.Should().Be("Waitlisted");
+        result.WaitlistPosition.Should().Be(1);
+        result.TeamAssignment.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateGhostPlayerAsync_RebuildsPositionsDict_DefaultsBronze()
+    {
+        // Arrange
+        var organizer = await CreateTestUser("organizer@example.com");
+        var evt = await CreateTestEvent(organizer.Id, maxPlayers: 10, cost: 0);
+        var created = await _sut.CreateGhostPlayerAsync(
+            evt.Id, organizer.Id, "John", "Doe", "Skater", "Gold");
+
+        // Act - switch to Goalie without a skill level
+        await _sut.UpdateGhostPlayerAsync(
+            evt.Id, organizer.Id, created.User.Id, "John", "Doe", "Goalie", null);
+
+        // Assert - single-entry dict keyed by the new position, skill defaults to Bronze (mirrors creation)
+        var ghostUser = await _context.Users.FirstAsync(u => u.Id == created.User.Id);
+        ghostUser.Positions.Should().HaveCount(1);
+        ghostUser.Positions.Should().ContainKey("goalie");
+        ghostUser.Positions!["goalie"].Should().Be("Bronze");
+    }
+
+    #endregion
+
     #region GroupMe Link Tests
 
     private static UpdateEventRequest GroupMeLinkUpdateRequest(string? groupMeLink)

--- a/apps/api/BHMHockey.Api/Controllers/EventsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/EventsController.cs
@@ -613,6 +613,37 @@ public class EventsController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Update a ghost player's name, position, and skill level in place (organizer only).
+    /// The registration is never released during the edit, so the roster spot is preserved.
+    /// </summary>
+    [Authorize]
+    [HttpPut("{eventId:guid}/registrations/ghost-players/{userId:guid}")]
+    public async Task<ActionResult<EventRegistrationDto>> UpdateGhostPlayer(
+        Guid eventId,
+        Guid userId,
+        [FromBody] UpdateGhostPlayerRequest request)
+    {
+        var organizerId = GetCurrentUserId();
+
+        try
+        {
+            var registration = await _eventService.UpdateGhostPlayerAsync(
+                eventId, organizerId, userId, request.FirstName, request.LastName, request.Position, request.SkillLevel);
+            return Ok(registration);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return Forbid();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Ghost player update rejected for event {EventId}, user {UserId}: {Message}",
+                eventId, userId, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
     #endregion
 
     #region Roster Order

--- a/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
@@ -195,3 +195,11 @@ public record CreateGhostPlayerRequest(
     string Position,                      // "Goalie" or "Skater"
     string? SkillLevel = null             // Optional: "Gold", "Silver", "Bronze", "D-League"
 );
+
+// Request to update a ghost player in place (mirrors CreateGhostPlayerRequest)
+public record UpdateGhostPlayerRequest(
+    string FirstName,
+    string LastName,
+    string Position,                      // "Goalie" or "Skater"
+    string? SkillLevel = null             // Optional: "Gold", "Silver", "Bronze", "D-League"
+);

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -2077,6 +2077,104 @@ public class EventService : IEventService
     }
 
     /// <summary>
+    /// Update a ghost player's name, position, and skill level in place (organizer only).
+    /// The registration is updated atomically - the roster spot is never released,
+    /// so real players can't grab it mid-edit. No notifications are sent (ghosts have no devices).
+    /// </summary>
+    public async Task<EventRegistrationDto> UpdateGhostPlayerAsync(
+        Guid eventId,
+        Guid organizerId,
+        Guid ghostUserId,
+        string firstName,
+        string lastName,
+        string position,
+        string? skillLevel)
+    {
+        // Load event
+        var evt = await _context.Events
+            .Include(e => e.Registrations)
+            .FirstOrDefaultAsync(e => e.Id == eventId);
+
+        if (evt == null)
+        {
+            throw new InvalidOperationException("Event not found");
+        }
+
+        // Verify organizer can manage this event
+        if (!await CanUserManageEventAsync(evt, organizerId))
+        {
+            throw new UnauthorizedAccessException("You don't have permission to manage this event");
+        }
+
+        // Validate position and skill level (same rules as creation)
+        var registeredPosition = NormalizePosition(position);
+        var normalizedPositionKey = registeredPosition.ToLowerInvariant();
+        if (!string.IsNullOrEmpty(skillLevel) && !ValidSkillLevels.Contains(skillLevel))
+        {
+            throw new InvalidOperationException($"Invalid skill level: '{skillLevel}'. Valid values: Gold, Silver, Bronze, D-League");
+        }
+
+        // Only ghost players can be edited - real users own their own profiles
+        var ghostUser = await _context.Users.FirstOrDefaultAsync(u => u.Id == ghostUserId);
+        if (ghostUser == null)
+        {
+            throw new InvalidOperationException("Player not found");
+        }
+
+        if (!ghostUser.IsGhostPlayer)
+        {
+            throw new InvalidOperationException("Only guest players can be edited. This player has a real account.");
+        }
+
+        // Must have an active registration on this event
+        var registration = evt.Registrations
+            .FirstOrDefault(r => r.UserId == ghostUserId
+                && (r.Status == "Registered" || r.Status == "Waitlisted"));
+
+        if (registration == null)
+        {
+            throw new InvalidOperationException("This guest player is not registered for this event");
+        }
+
+        // Capacity rule on position change for a rostered ghost:
+        // Skater -> Goalie always allowed (frees a skater spot).
+        // Goalie -> Skater only if there's skater room (goalies don't count against MaxPlayers).
+        var positionChanged = registration.RegisteredPosition != registeredPosition;
+        if (positionChanged && registration.Status == "Registered" && registeredPosition == "Skater")
+        {
+            var skaterCount = evt.Registrations.Count(r => r.Status == "Registered" && r.RegisteredPosition != "Goalie");
+            if (skaterCount >= evt.MaxPlayers)
+            {
+                throw new InvalidOperationException("The roster is full for skaters. Free up a skater spot before switching this guest from Goalie to Skater.");
+            }
+        }
+
+        // Update ghost user fields; rebuild Positions to a single-entry dict (mirrors creation)
+        ghostUser.FirstName = firstName;
+        ghostUser.LastName = lastName;
+        ghostUser.Positions = new Dictionary<string, string>
+        {
+            { normalizedPositionKey, skillLevel ?? "Bronze" }
+        };
+        ghostUser.UpdatedAt = DateTime.UtcNow;
+
+        registration.RegisteredPosition = registeredPosition;
+
+        // Recompute team via the balancer only when a rostered ghost actually changes position
+        if (positionChanged && registration.Status == "Registered")
+        {
+            registration.TeamAssignment = await DetermineTeamAssignmentAsync(eventId, registeredPosition);
+        }
+
+        // Single UPDATE path - the registration row is never deleted, so the spot is never released
+        await _context.SaveChangesAsync();
+
+        registration.User = ghostUser;
+
+        return MapRegistrationToDto(registration);
+    }
+
+    /// <summary>
     /// Notify a user that they have been added directly to an event's roster by an organizer.
     /// </summary>
     private async Task NotifyUserAddedToRosterAsync(Models.Entities.Event evt, Models.Entities.User user, string? teamAssignment)

--- a/apps/api/BHMHockey.Api/Services/IEventService.cs
+++ b/apps/api/BHMHockey.Api/Services/IEventService.cs
@@ -76,4 +76,10 @@ public interface IEventService
     /// Ghost players are placeholder accounts for people who don't have the app.
     /// </summary>
     Task<EventRegistrationDto> CreateGhostPlayerAsync(Guid eventId, Guid organizerId, string firstName, string lastName, string position, string? skillLevel);
+
+    /// <summary>
+    /// Update a ghost player's name, position, and skill level in place (organizer only).
+    /// The registration is updated atomically - the roster spot is never released.
+    /// </summary>
+    Task<EventRegistrationDto> UpdateGhostPlayerAsync(Guid eventId, Guid organizerId, Guid ghostUserId, string firstName, string lastName, string position, string? skillLevel);
 }

--- a/apps/mobile/__tests__/stores/eventStore.test.ts
+++ b/apps/mobile/__tests__/stores/eventStore.test.ts
@@ -16,6 +16,7 @@ const mockCancelRegistration = jest.fn();
 const mockGetMyRegistrations = jest.fn();
 const mockReorderWaitlist = jest.fn();
 const mockMarkPayment = jest.fn();
+const mockUpdateGhostPlayer = jest.fn();
 
 // Mock the api-client module
 jest.mock('@bhmhockey/api-client', () => ({
@@ -28,6 +29,7 @@ jest.mock('@bhmhockey/api-client', () => ({
     getMyRegistrations: mockGetMyRegistrations,
     reorderWaitlist: mockReorderWaitlist,
     markPayment: mockMarkPayment,
+    updateGhostPlayer: mockUpdateGhostPlayer,
   },
 }));
 
@@ -559,6 +561,61 @@ describe('eventStore', () => {
       expect(useEventStore.getState().events[0].myPaymentStatus).toBe('Pending');
       // Server message surfaced for the UI
       expect(useEventStore.getState().error).toBe(serverMessage);
+    });
+  });
+
+  describe('updateGhostPlayer', () => {
+    it('calls the API and refreshes event data on success', async () => {
+      const event = createMockEvent({ id: 'event-1' });
+      useEventStore.setState({ selectedEvent: event });
+      mockUpdateGhostPlayer.mockResolvedValue({ id: 'reg-1' });
+      mockGetById.mockResolvedValue(event);
+
+      const result = await useEventStore
+        .getState()
+        .updateGhostPlayer('event-1', 'ghost-user-1', 'Jane', 'Smith', 'Goalie', 'Silver');
+
+      expect(result).toBe(true);
+      expect(mockUpdateGhostPlayer).toHaveBeenCalledWith('event-1', 'ghost-user-1', {
+        firstName: 'Jane',
+        lastName: 'Smith',
+        position: 'Goalie',
+        skillLevel: 'Silver',
+      });
+      expect(mockGetById).toHaveBeenCalledWith('event-1');
+      expect(useEventStore.getState().error).toBeNull();
+    });
+
+    it('omits skillLevel when not provided', async () => {
+      mockUpdateGhostPlayer.mockResolvedValue({ id: 'reg-1' });
+      mockGetById.mockResolvedValue(createMockEvent({ id: 'event-1' }));
+
+      await useEventStore
+        .getState()
+        .updateGhostPlayer('event-1', 'ghost-user-1', 'Jane', 'Smith', 'Skater');
+
+      expect(mockUpdateGhostPlayer).toHaveBeenCalledWith('event-1', 'ghost-user-1', {
+        firstName: 'Jane',
+        lastName: 'Smith',
+        position: 'Skater',
+        skillLevel: undefined,
+      });
+    });
+
+    it('returns false and surfaces the server message on failure (roster full for skaters)', async () => {
+      const serverMessage =
+        'The roster is full for skaters. Free up a skater spot before switching this guest from Goalie to Skater.';
+      // The axios interceptor rejects with a plain ApiError object (not an Error instance)
+      mockUpdateGhostPlayer.mockRejectedValue({ message: serverMessage });
+
+      const result = await useEventStore
+        .getState()
+        .updateGhostPlayer('event-1', 'ghost-user-1', 'Jane', 'Smith', 'Skater');
+
+      expect(result).toBe(false);
+      expect(useEventStore.getState().error).toBe(serverMessage);
+      // No refresh on failure
+      expect(mockGetById).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/mobile/components/PlayerDetailModal.tsx
+++ b/apps/mobile/components/PlayerDetailModal.tsx
@@ -31,6 +31,8 @@ interface PlayerDetailModalProps {
   onMoveToRoster?: (registration: EventRegistrationDto) => void;
   /** Move rostered player to waitlist (organizer only) */
   onMoveToWaitlist?: (registration: EventRegistrationDto) => void;
+  /** Edit a guest (ghost) player in place (organizer only; shown only for ghost players) */
+  onEditGuest?: (registration: EventRegistrationDto) => void;
 }
 
 const getPaymentStatusDisplay = (status?: string): { label: string; color: string } => {
@@ -58,6 +60,7 @@ export function PlayerDetailModal({
   onResetPayment,
   onMoveToRoster,
   onMoveToWaitlist,
+  onEditGuest,
 }: PlayerDetailModalProps) {
   const [badges, setBadges] = useState<UserBadgeDto[]>([]);
   const [isLoadingBadges, setIsLoadingBadges] = useState(false);
@@ -138,10 +141,18 @@ export function PlayerDetailModal({
     onClose();
   };
 
+  const handleEditGuest = () => {
+    onEditGuest?.(registration);
+    onClose();
+  };
+
+  // Edit Guest is only available for ghost (guest) players
+  const canEditGuest = user.isGhostPlayer === true && !!onEditGuest;
+
   // Check if we have any admin actions to show
   const hasAdminActions = isAdmin && (
     onSwapTeam || onRemove || onMarkPaid || onVerifyPayment || onResetPayment ||
-    onMoveToRoster || onMoveToWaitlist
+    onMoveToRoster || onMoveToWaitlist || canEditGuest
   );
 
   return (
@@ -211,6 +222,13 @@ export function PlayerDetailModal({
                 {/* Admin Actions */}
                 {hasAdminActions && (
                   <View style={styles.actions}>
+                    {/* Edit Guest - only for ghost players when organizer */}
+                    {canEditGuest && (
+                      <TouchableOpacity style={styles.actionButton} onPress={handleEditGuest}>
+                        <Text style={styles.actionButtonText} allowFontScaling={false}>Edit Guest</Text>
+                      </TouchableOpacity>
+                    )}
+
                     {/* Swap Team */}
                     {onSwapTeam && (
                       <TouchableOpacity style={styles.actionButton} onPress={handleSwapTeam}>

--- a/apps/mobile/components/event-detail/AddPlayerModal.tsx
+++ b/apps/mobile/components/event-detail/AddPlayerModal.tsx
@@ -15,7 +15,7 @@ import {
   Platform,
   ScrollView,
 } from 'react-native';
-import type { UserSearchResultDto, SkillLevel } from '@bhmhockey/shared';
+import type { UserSearchResultDto, SkillLevel, EventRegistrationDto } from '@bhmhockey/shared';
 import { useEventStore } from '../../stores/eventStore';
 import { colors, spacing, radius } from '../../theme';
 
@@ -26,6 +26,8 @@ interface AddPlayerModalProps {
   eventId: string;
   onClose: () => void;
   onPlayerAdded: () => void;
+  /** When set, the modal opens in edit mode: only the guest form is shown, pre-filled with this ghost player's values */
+  editingRegistration?: EventRegistrationDto | null;
 }
 
 export function AddPlayerModal({
@@ -33,6 +35,7 @@ export function AddPlayerModal({
   eventId,
   onClose,
   onPlayerAdded,
+  editingRegistration,
 }: AddPlayerModalProps) {
   // Tab state
   const [activeTab, setActiveTab] = useState<TabType>('search');
@@ -53,7 +56,9 @@ export function AddPlayerModal({
   const [guestSkillLevel, setGuestSkillLevel] = useState<SkillLevel | null>(null);
   const [isCreatingGuest, setIsCreatingGuest] = useState(false);
 
-  const { searchUsersForEvent, addUserToEvent, createGhostPlayer } = useEventStore();
+  const { searchUsersForEvent, addUserToEvent, createGhostPlayer, updateGhostPlayer } = useEventStore();
+
+  const isEditMode = !!editingRegistration;
 
   // Reset state when modal opens/closes
   useEffect(() => {
@@ -75,6 +80,22 @@ export function AddPlayerModal({
       setIsCreatingGuest(false);
     }
   }, [visible]);
+
+  // Edit mode: pre-fill the guest form with the ghost player's current values
+  useEffect(() => {
+    if (visible && editingRegistration) {
+      const { user, registeredPosition } = editingRegistration;
+      const position = registeredPosition === 'Goalie' ? 'Goalie' : 'Skater';
+      setGuestFirstName(user.firstName);
+      setGuestLastName(user.lastName);
+      setGuestPosition(position);
+      // Ghost players have a single-entry positions dict; prefer the registered position's skill
+      const skill = position === 'Goalie'
+        ? user.positions?.goalie ?? user.positions?.skater
+        : user.positions?.skater ?? user.positions?.goalie;
+      setGuestSkillLevel(skill ?? null);
+    }
+  }, [visible, editingRegistration]);
 
   // Debounced search
   useEffect(() => {
@@ -130,7 +151,7 @@ export function AddPlayerModal({
     }
   };
 
-  const handleCreateGuest = async () => {
+  const handleSubmitGuest = async () => {
     if (!guestFirstName.trim()) {
       Alert.alert('Required', 'Please enter a first name.');
       return;
@@ -145,18 +166,30 @@ export function AddPlayerModal({
     }
 
     setIsCreatingGuest(true);
-    const success = await createGhostPlayer(
-      eventId,
-      guestFirstName.trim(),
-      guestLastName.trim(),
-      guestPosition,
-      guestSkillLevel || undefined
-    );
+    const success = editingRegistration
+      ? await updateGhostPlayer(
+          eventId,
+          editingRegistration.user.id,
+          guestFirstName.trim(),
+          guestLastName.trim(),
+          guestPosition,
+          guestSkillLevel || undefined
+        )
+      : await createGhostPlayer(
+          eventId,
+          guestFirstName.trim(),
+          guestLastName.trim(),
+          guestPosition,
+          guestSkillLevel || undefined
+        );
     setIsCreatingGuest(false);
 
     if (success) {
       onPlayerAdded();
       onClose();
+    } else if (editingRegistration) {
+      // Surface the server's message (e.g. roster full for skaters) to the organizer
+      Alert.alert('Error', useEventStore.getState().error || 'Failed to update guest player');
     }
   };
 
@@ -207,39 +240,43 @@ export function AddPlayerModal({
               <View style={styles.modal}>
                 {/* Header */}
                 <View style={styles.header}>
-                  <Text style={styles.title} allowFontScaling={false}>Add Player</Text>
+                  <Text style={styles.title} allowFontScaling={false}>
+                    {isEditMode ? 'Edit Guest' : 'Add Player'}
+                  </Text>
                   <TouchableOpacity onPress={onClose} style={styles.closeButton}>
                     <Text style={styles.closeButtonText} allowFontScaling={false}>Cancel</Text>
                   </TouchableOpacity>
                 </View>
 
-                {/* Tab Toggle */}
-                <View style={styles.tabContainer}>
-                  <TouchableOpacity
-                    style={[styles.tab, activeTab === 'search' && styles.tabActive]}
-                    onPress={() => setActiveTab('search')}
-                  >
-                    <Text
-                      style={[styles.tabText, activeTab === 'search' && styles.tabTextActive]}
-                      allowFontScaling={false}
+                {/* Tab Toggle - hidden in edit mode (guest form only) */}
+                {!isEditMode && (
+                  <View style={styles.tabContainer}>
+                    <TouchableOpacity
+                      style={[styles.tab, activeTab === 'search' && styles.tabActive]}
+                      onPress={() => setActiveTab('search')}
                     >
-                      Search
-                    </Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.tab, activeTab === 'create' && styles.tabActive]}
-                    onPress={() => setActiveTab('create')}
-                  >
-                    <Text
-                      style={[styles.tabText, activeTab === 'create' && styles.tabTextActive]}
-                      allowFontScaling={false}
+                      <Text
+                        style={[styles.tabText, activeTab === 'search' && styles.tabTextActive]}
+                        allowFontScaling={false}
+                      >
+                        Search
+                      </Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[styles.tab, activeTab === 'create' && styles.tabActive]}
+                      onPress={() => setActiveTab('create')}
                     >
-                      Create Guest
-                    </Text>
-                  </TouchableOpacity>
-                </View>
+                      <Text
+                        style={[styles.tabText, activeTab === 'create' && styles.tabTextActive]}
+                        allowFontScaling={false}
+                      >
+                        Create Guest
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                )}
 
-                {activeTab === 'search' ? (
+                {!isEditMode && activeTab === 'search' ? (
                   <>
                     {/* Search Input */}
                     <View style={styles.searchContainer}>
@@ -491,20 +528,20 @@ export function AddPlayerModal({
                       </View>
                     </View>
 
-                    {/* Create Guest Button */}
+                    {/* Create Guest / Save Changes Button */}
                     <TouchableOpacity
                       style={[
                         styles.confirmButton,
                         (!guestFirstName.trim() || !guestLastName.trim() || !guestPosition) && styles.confirmButtonDisabled,
                       ]}
-                      onPress={handleCreateGuest}
+                      onPress={handleSubmitGuest}
                       disabled={isCreatingGuest || !guestFirstName.trim() || !guestLastName.trim() || !guestPosition}
                     >
                       {isCreatingGuest ? (
                         <ActivityIndicator size="small" color={colors.text.primary} />
                       ) : (
                         <Text style={styles.confirmButtonText} allowFontScaling={false}>
-                          Create Guest
+                          {isEditMode ? 'Save Changes' : 'Create Guest'}
                         </Text>
                       )}
                     </TouchableOpacity>

--- a/apps/mobile/components/event-detail/EventRosterTab.tsx
+++ b/apps/mobile/components/event-detail/EventRosterTab.tsx
@@ -51,6 +51,7 @@ export function EventRosterTab({ eventId, event, canManage }: EventRosterTabProp
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const [isAddPlayerModalVisible, setIsAddPlayerModalVisible] = useState(false);
+  const [editingGuest, setEditingGuest] = useState<EventRegistrationDto | null>(null);
   const isUpdatingRoster = useRef(false);
   const hasLoadedOnce = useRef(false);
   const [isShareModalVisible, setIsShareModalVisible] = useState(false);
@@ -137,6 +138,12 @@ export function EventRosterTab({ eventId, event, canManage }: EventRosterTabProp
   const handlePlayerAdded = () => {
     // Reload registrations to show the newly added player
     reloadRegistrations();
+  };
+
+  // Open the guest form in edit mode for a ghost player (organizer only)
+  const handleEditGuest = (registration: EventRegistrationDto) => {
+    setEditingGuest(registration);
+    setIsAddPlayerModalVisible(true);
   };
 
   const handlePublishRoster = async () => {
@@ -651,14 +658,19 @@ export function EventRosterTab({ eventId, event, canManage }: EventRosterTabProp
         onResetPayment={canManage ? handleResetPayment : undefined}
         onMoveToRoster={canManage && selectedPlayer?.isWaitlisted ? handleMoveToRoster : undefined}
         onMoveToWaitlist={canManage && !selectedPlayer?.isWaitlisted ? handleMoveToWaitlist : undefined}
+        onEditGuest={canManage ? handleEditGuest : undefined}
       />
 
-      {/* Add Player Modal */}
+      {/* Add Player Modal (also used in edit mode for guest players) */}
       <AddPlayerModal
         visible={isAddPlayerModalVisible}
         eventId={eventId}
-        onClose={() => setIsAddPlayerModalVisible(false)}
+        onClose={() => {
+          setIsAddPlayerModalVisible(false);
+          setEditingGuest(null);
+        }}
         onPlayerAdded={handlePlayerAdded}
+        editingRegistration={editingGuest}
       />
 
       {/* Off-screen card for capture */}

--- a/apps/mobile/stores/eventStore.ts
+++ b/apps/mobile/stores/eventStore.ts
@@ -53,6 +53,7 @@ interface EventState {
   searchUsersForEvent: (eventId: string, query: string) => Promise<UserSearchResultDto[]>;
   addUserToEvent: (eventId: string, userId: string, position?: string) => Promise<boolean>;
   createGhostPlayer: (eventId: string, firstName: string, lastName: string, position: 'Goalie' | 'Skater', skillLevel?: string) => Promise<boolean>;
+  updateGhostPlayer: (eventId: string, userId: string, firstName: string, lastName: string, position: 'Goalie' | 'Skater', skillLevel?: string) => Promise<boolean>;
 }
 
 export const useEventStore = create<EventState>((set, get) => ({
@@ -464,6 +465,24 @@ export const useEventStore = create<EventState>((set, get) => ({
       return true;
     } catch (error: any) {
       set({ error: getErrorMessage(error, 'Failed to create guest player') });
+      return false;
+    }
+  },
+
+  // Update a ghost player in place (organizer only) - the roster spot is never released
+  updateGhostPlayer: async (eventId, userId, firstName, lastName, position, skillLevel) => {
+    try {
+      await eventService.updateGhostPlayer(eventId, userId, {
+        firstName,
+        lastName,
+        position,
+        skillLevel: skillLevel as SkillLevel | undefined,
+      });
+      // Refresh event data to get updated registrations
+      await get().fetchEventById(eventId);
+      return true;
+    } catch (error: any) {
+      set({ error: getErrorMessage(error, 'Failed to update guest player') });
       return false;
     }
   },

--- a/packages/api-client/__tests__/services/events.test.ts
+++ b/packages/api-client/__tests__/services/events.test.ts
@@ -95,4 +95,38 @@ describe('eventService waitlist visibility & payment', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('updateGhostPlayer', () => {
+    it('puts the guest edit to the ghost-players endpoint', async () => {
+      const request = {
+        firstName: 'Jane',
+        lastName: 'Smith',
+        position: 'Goalie' as const,
+        skillLevel: 'Silver' as const,
+      };
+      const updated = { id: 'reg-1', registeredPosition: 'Goalie' };
+      mockPut.mockResolvedValueOnce({ data: updated });
+
+      const result = await eventService.updateGhostPlayer('event-1', 'ghost-user-1', request);
+
+      expect(mockPut).toHaveBeenCalledWith(
+        '/events/event-1/registrations/ghost-players/ghost-user-1',
+        request
+      );
+      expect(result).toEqual(updated);
+    });
+
+    it('surfaces server rejection (roster full for skaters)', async () => {
+      const apiError = { message: 'The roster is full for skaters. Free up a skater spot before switching this guest from Goalie to Skater.' };
+      mockPut.mockRejectedValueOnce(apiError);
+
+      await expect(
+        eventService.updateGhostPlayer('event-1', 'ghost-user-1', {
+          firstName: 'Jane',
+          lastName: 'Smith',
+          position: 'Skater',
+        })
+      ).rejects.toEqual(apiError);
+    });
+  });
 });

--- a/packages/api-client/src/services/events.ts
+++ b/packages/api-client/src/services/events.ts
@@ -18,7 +18,8 @@ import type {
   WaitlistOrderItem,
   UserSearchResultDto,
   AddUserToEventRequest,
-  CreateGhostPlayerRequest
+  CreateGhostPlayerRequest,
+  UpdateGhostPlayerRequest
 } from '@bhmhockey/shared';
 import { apiClient } from '../client';
 
@@ -249,6 +250,18 @@ export const eventService = {
   async createGhostPlayer(eventId: string, request: CreateGhostPlayerRequest): Promise<EventRegistrationDto> {
     const response = await apiClient.instance.post<EventRegistrationDto>(
       `/events/${eventId}/registrations/create-ghost-player`,
+      request
+    );
+    return response.data;
+  },
+
+  /**
+   * Update a ghost player's name, position, and skill level in place (organizer only).
+   * The registration is never released during the edit, so the roster spot is preserved.
+   */
+  async updateGhostPlayer(eventId: string, userId: string, request: UpdateGhostPlayerRequest): Promise<EventRegistrationDto> {
+    const response = await apiClient.instance.put<EventRegistrationDto>(
+      `/events/${eventId}/registrations/ghost-players/${userId}`,
       request
     );
     return response.data;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -31,6 +31,14 @@ export interface CreateGhostPlayerRequest {
   skillLevel?: SkillLevel;
 }
 
+// Ghost player in-place update request (mirrors CreateGhostPlayerRequest)
+export interface UpdateGhostPlayerRequest {
+  firstName: string;
+  lastName: string;
+  position: 'Goalie' | 'Skater';
+  skillLevel?: SkillLevel;
+}
+
 // Position-skill mapping for multi-position support
 export type UserPositions = {
   goalie?: SkillLevel;


### PR DESCRIPTION
## Summary

Organizers can now edit guest (ghost) players in place — the same fields entered at creation (first name, last name, position, skill level), through the same form. Previously a wrong name or position meant remove-and-recreate, which transiently released the roster spot where a real player could grab it. The edit is a single-update path: the spot is never released.

## Behavior

- New endpoint `PUT events/{eventId}/registrations/ghost-players/{userId}` (request mirrors create-ghost). Manager-only (403 otherwise); guests only — real accounts rejected with a clear 400; requires an active registration on the event.
- Position changes on a rostered guest: Skater→Goalie always allowed (frees a skater spot); Goalie→Skater blocked with a clear 400 when skater spots are full. Team assignment recomputes via the existing balancer only when position actually changes. Waitlisted guests: fields update, queue position untouched.
- No notifications (guests have no devices).
- Mobile: tapping a guest row in the roster shows an "Edit Guest" action (organizer-only, guest-only) which opens the existing create-guest form in edit mode — pre-filled, titled "Edit Guest", button "Save Changes". Reuses the AddPlayerModal form, so create and edit are identical by construction.
- No migration (no schema changes). `UpdateGhostPlayerRequest` mirrored in `@bhmhockey/shared`; `updateGhostPlayer` added to the api-client and eventStore following existing patterns.

## Testing

- API suite: 991 → 1007 (manager/ghost/active-registration guards, validation, both position-change directions incl. the full-roster block leaving the registration untouched, balancer recompute only on position change, waitlisted edits, positions-dict rebuild)
- Frontend: api-client 31→33, mobile 87→90, shared 41; mobile type-check clean
- Live E2E: 6 scenarios verified against a throwaway org (incl. registration-identity preservation on name-only edit and full regression of create-ghost), cleaned up afterward
- Manually tested in the iOS simulator by @auc0le

🤖 Generated with [Claude Code](https://claude.com/claude-code)