### PR TITLE
Show organized games only in the organizing section on home

### DIFF
--- a/apps/mobile/app/(tabs)/index.tsx
+++ b/apps/mobile/app/(tabs)/index.tsx
@@ -44,10 +44,12 @@ export default function HomeScreen() {
   const sortByDate = (a: typeof events[0], b: typeof events[0]) =>
     new Date(a.eventDate).getTime() - new Date(b.eventDate).getTime();
 
-  // Derived data - all sorted by event date
+  // Derived data - all sorted by event date.
+  // Events the user organizes appear ONLY in "Games I'm Organizing" -
+  // excluded from Available and My Upcoming so nothing shows twice.
   const availableGames = useMemo(() =>
     events
-      .filter(e => !e.isRegistered && !e.amIWaitlisted && e.status === 'Published')
+      .filter(e => !e.isRegistered && !e.amIWaitlisted && !e.canManage && e.status === 'Published')
       .sort(sortByDate),
     [events]
   );
@@ -67,7 +69,9 @@ export default function HomeScreen() {
           myWaitlistedGames.map(event => [event.id, event])
         ))
         .values()
-    ).sort(sortByDate),
+    )
+      .filter(e => !e.canManage)
+      .sort(sortByDate),
     [myRegistrations, myWaitlistedGames]
   );
 

--- a/apps/mobile/components/EventCard.tsx
+++ b/apps/mobile/components/EventCard.tsx
@@ -225,6 +225,10 @@ function OrganizingBadges({ event }: { event: EventDto }) {
   return (
     <View style={styles.organizerStats}>
       <Badge variant="purple">{event.registeredCount}/{event.maxPlayers}</Badge>
+      {/* Organized games no longer appear under My Upcoming Games, so flag the ones the organizer also plays in */}
+      {(event.isRegistered || event.amIWaitlisted) && (
+        <Badge variant="green">Playing</Badge>
+      )}
       {event.cost > 0 && event.unpaidCount !== undefined && event.unpaidCount > 0 && (
         <Badge variant="error">{event.unpaidCount} unpaid</Badge>
       )}


### PR DESCRIPTION
## Summary

The home tab duplicated games the user organizes: organized-and-playing games appeared in both "My Upcoming Games" and "Games I'm Organizing", and organized-but-not-playing games in both "Upcoming Available Games" and "Games I'm Organizing". One rule now applies: anything the user organizes renders solely under "Games I'm Organizing".

To keep the at-a-glance "am I playing in this one?" signal, organizing cards show a green **Playing** badge when the organizer is also registered or waitlisted in that game.

The Events tab needs no change — it's a single list where the organizing variant already takes precedence.

## Testing

- Purely client-side (two files, no API/shared-type changes); mobile type-check clean, 90 mobile tests pass
- Manually verified in the iOS simulator by @auc0le

🤖 Generated with [Claude Code](https://claude.com/claude-code)