### PR TITLE
Add organization legal waivers with accept-or-leave gating and PDF export

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
@@ -20,6 +20,7 @@ public class OrganizationsControllerTests
     private readonly Mock<IOrganizationService> _mockOrgService;
     private readonly Mock<IOrganizationAdminService> _mockAdminService;
     private readonly Mock<IOrganizationAutoRosterService> _mockAutoRosterService;
+    private readonly Mock<IOrganizationWaiverService> _mockWaiverService;
     private readonly OrganizationsController _controller;
     private readonly Guid _testUserId = Guid.NewGuid();
 
@@ -28,10 +29,12 @@ public class OrganizationsControllerTests
         _mockOrgService = new Mock<IOrganizationService>();
         _mockAdminService = new Mock<IOrganizationAdminService>();
         _mockAutoRosterService = new Mock<IOrganizationAutoRosterService>();
+        _mockWaiverService = new Mock<IOrganizationWaiverService>();
         _controller = new OrganizationsController(
             _mockOrgService.Object,
             _mockAdminService.Object,
             _mockAutoRosterService.Object,
+            _mockWaiverService.Object,
             Mock.Of<ILogger<OrganizationsController>>());
     }
 
@@ -469,6 +472,169 @@ public class OrganizationsControllerTests
 
         // Assert
         result.Result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    #endregion
+
+    #region Waiver Endpoint Tests
+
+    private static OrganizationWaiverDto CreateWaiverDto(Guid? orgId = null, int version = 1, string text = "Waiver text")
+    {
+        return new OrganizationWaiverDto(
+            Guid.NewGuid(),
+            orgId ?? Guid.NewGuid(),
+            text,
+            version,
+            DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task GetWaiver_WithActiveWaiver_ReturnsOk()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var waiver = CreateWaiverDto(orgId);
+        _mockWaiverService.Setup(s => s.GetCurrentWaiverAsync(orgId)).ReturnsAsync(waiver);
+
+        // Act
+        var result = await _controller.GetWaiver(orgId);
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().Be(waiver);
+    }
+
+    [Fact]
+    public async Task GetWaiver_WithNoActiveWaiver_Returns404()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        _mockWaiverService.Setup(s => s.GetCurrentWaiverAsync(orgId)).ReturnsAsync((OrganizationWaiverDto?)null);
+
+        // Act
+        var result = await _controller.GetWaiver(orgId);
+
+        // Assert
+        result.Result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task SetWaiver_AsAdmin_ReturnsOkWithNewVersion()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var waiver = CreateWaiverDto(orgId, version: 2);
+        _mockWaiverService.Setup(s => s.SetWaiverAsync(orgId, "New text", _testUserId)).ReturnsAsync(waiver);
+
+        // Act
+        var result = await _controller.SetWaiver(orgId, new SetOrganizationWaiverRequest("New text"));
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<SetOrganizationWaiverResponse>().Subject;
+        response.Waiver.Should().Be(waiver);
+    }
+
+    [Fact]
+    public async Task SetWaiver_AsNonAdmin_Returns403()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        _mockWaiverService.Setup(s => s.SetWaiverAsync(orgId, It.IsAny<string?>(), _testUserId))
+            .ThrowsAsync(new UnauthorizedAccessException("Only organization admins can update the waiver"));
+
+        // Act
+        var result = await _controller.SetWaiver(orgId, new SetOrganizationWaiverRequest("New text"));
+
+        // Assert
+        result.Result.Should().BeOfType<ForbidResult>();
+    }
+
+    [Fact]
+    public async Task GetWaiverPdf_WithActiveWaiver_ReturnsPdfFile()
+    {
+        // Arrange - endpoint is anonymous by design, no auth setup
+        var orgId = Guid.NewGuid();
+        var pdfBytes = new byte[] { 0x25, 0x50, 0x44, 0x46 }; // %PDF
+        _mockWaiverService.Setup(s => s.GetCurrentWaiverPdfAsync(orgId))
+            .ReturnsAsync((pdfBytes, "test-org-waiver-v1.pdf"));
+
+        // Act
+        var result = await _controller.GetWaiverPdf(orgId);
+
+        // Assert
+        var fileResult = result.Should().BeOfType<FileContentResult>().Subject;
+        fileResult.ContentType.Should().Be("application/pdf");
+        fileResult.FileDownloadName.Should().Be("test-org-waiver-v1.pdf");
+        fileResult.FileContents.Should().Equal(pdfBytes);
+    }
+
+    [Fact]
+    public async Task GetWaiverPdf_WithNoActiveWaiver_Returns404()
+    {
+        // Arrange
+        var orgId = Guid.NewGuid();
+        _mockWaiverService.Setup(s => s.GetCurrentWaiverPdfAsync(orgId))
+            .ReturnsAsync(((byte[], string)?)null);
+
+        // Act
+        var result = await _controller.GetWaiverPdf(orgId);
+
+        // Assert
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task AcceptWaiver_WithCurrentVersion_ReturnsOk()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var waiverId = Guid.NewGuid();
+
+        // Act
+        var result = await _controller.AcceptWaiver(orgId, new AcceptWaiverRequest(waiverId));
+
+        // Assert
+        result.Should().BeOfType<OkObjectResult>();
+        _mockWaiverService.Verify(s => s.AcceptWaiverAsync(orgId, waiverId, _testUserId), Times.Once);
+    }
+
+    [Fact]
+    public async Task AcceptWaiver_WithStaleVersion_Returns400()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var staleWaiverId = Guid.NewGuid();
+        _mockWaiverService.Setup(s => s.AcceptWaiverAsync(orgId, staleWaiverId, _testUserId))
+            .ThrowsAsync(new InvalidOperationException("This waiver version is no longer current."));
+
+        // Act
+        var result = await _controller.AcceptWaiver(orgId, new AcceptWaiverRequest(staleWaiverId));
+
+        // Assert
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task Leave_DelegatesToServiceAndReturnsOk()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        _mockOrgService.Setup(s => s.LeaveAsync(orgId, _testUserId)).ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.Leave(orgId);
+
+        // Assert
+        result.Should().BeOfType<OkObjectResult>();
+        _mockOrgService.Verify(s => s.LeaveAsync(orgId, _testUserId), Times.Once);
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Controllers/UsersControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/UsersControllerTests.cs
@@ -22,6 +22,7 @@ public class UsersControllerTests
     private readonly Mock<IBadgeService> _mockBadgeService;
     private readonly Mock<ITournamentTeamMemberService> _mockTournamentTeamMemberService;
     private readonly Mock<ITournamentService> _mockTournamentService;
+    private readonly Mock<IOrganizationWaiverService> _mockWaiverService;
     private readonly UsersController _sut;
 
     public UsersControllerTests()
@@ -32,13 +33,15 @@ public class UsersControllerTests
         _mockBadgeService = new Mock<IBadgeService>();
         _mockTournamentTeamMemberService = new Mock<ITournamentTeamMemberService>();
         _mockTournamentService = new Mock<ITournamentService>();
+        _mockWaiverService = new Mock<IOrganizationWaiverService>();
         _sut = new UsersController(
             _mockUserService.Object,
             _mockOrgService.Object,
             _mockEventService.Object,
             _mockBadgeService.Object,
             _mockTournamentTeamMemberService.Object,
-            _mockTournamentService.Object);
+            _mockTournamentService.Object,
+            _mockWaiverService.Object);
     }
 
     private void SetupControllerWithClaims(IEnumerable<Claim> claims)
@@ -338,6 +341,50 @@ public class UsersControllerTests
         var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
         var returnedEvents = okResult.Value as List<EventDto>;
         returnedEvents.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Pending Waivers Endpoint Tests
+
+    [Fact]
+    public async Task GetMyPendingWaivers_ReturnsPendingListForCurrentUser()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var claims = new List<Claim> { new Claim("sub", userId.ToString()) };
+        SetupControllerWithClaims(claims);
+        var pending = new List<PendingWaiverDto>
+        {
+            new PendingWaiverDto(
+                Guid.NewGuid(),
+                "Test Org",
+                new OrganizationWaiverDto(Guid.NewGuid(), Guid.NewGuid(), "Waiver text", 2, DateTime.UtcNow))
+        };
+        _mockWaiverService.Setup(s => s.GetPendingWaiversAsync(userId)).ReturnsAsync(pending);
+
+        // Act
+        var result = await _sut.GetMyPendingWaivers();
+
+        // Assert
+        var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var returned = okResult.Value.Should().BeAssignableTo<List<PendingWaiverDto>>().Subject;
+        returned.Should().HaveCount(1);
+        returned[0].OrganizationName.Should().Be("Test Org");
+        returned[0].Waiver.Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetMyPendingWaivers_WithNoClaims_ReturnsUnauthorized()
+    {
+        // Arrange
+        SetupControllerWithClaims(new List<Claim>());
+
+        // Act
+        var result = await _sut.GetMyPendingWaivers();
+
+        // Assert
+        result.Result.Should().BeOfType<UnauthorizedObjectResult>();
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -26,6 +26,7 @@ public class EventServiceTests : IDisposable
     private readonly Mock<INotificationService> _mockNotificationService;
     private readonly Mock<IWaitlistService> _mockWaitlistService;
     private readonly OrganizationAdminService _adminService;
+    private readonly OrganizationWaiverService _waiverService;
     private readonly EventService _sut;
 
     public EventServiceTests()
@@ -38,12 +39,14 @@ public class EventServiceTests : IDisposable
         _mockNotificationService = new Mock<INotificationService>();
         _mockWaitlistService = new Mock<IWaitlistService>();
         _adminService = new OrganizationAdminService(_context);
+        // Real waiver service so gate tests exercise real active-waiver semantics
+        _waiverService = new OrganizationWaiverService(_context, _adminService, Mock.Of<ILogger<OrganizationWaiverService>>());
 
         // Default mock setup for waitlist service
         _mockWaitlistService.Setup(w => w.GetNextWaitlistPositionAsync(It.IsAny<Guid>()))
             .ReturnsAsync(1);
 
-        _sut = new EventService(_context, _mockNotificationService.Object, _adminService, _mockWaitlistService.Object, Mock.Of<ILogger<EventService>>());
+        _sut = new EventService(_context, _mockNotificationService.Object, _adminService, _mockWaitlistService.Object, _waiverService, Mock.Of<ILogger<EventService>>());
     }
 
     public void Dispose()
@@ -4521,6 +4524,307 @@ public class EventServiceTests : IDisposable
             && r.PaymentVerifiedAt == null
             && r.PaymentDeadlineAt == null);
         result.Should().NotContain(r => r.User.Id == registered.Id);
+    }
+
+    #endregion
+
+    #region Waiver Gate Tests
+
+    private async Task<User> CreateGhostUser(string firstName = "Ghost", string lastName = "Player")
+    {
+        var ghost = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = $"ghost_{Guid.NewGuid():N}@placeholder.bhmhockey",
+            PasswordHash = "",
+            FirstName = firstName,
+            LastName = lastName,
+            IsGhostPlayer = true,
+            IsActive = true,
+            Role = "Player",
+            Positions = new Dictionary<string, string> { { "skater", "Bronze" } }
+        };
+        _context.Users.Add(ghost);
+        await _context.SaveChangesAsync();
+        return ghost;
+    }
+
+    [Fact]
+    public async Task RegisterAsync_OrgEventWithUnacceptedWaiver_ThrowsWithDistinctiveMessage()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Act
+        var act = () => _sut.RegisterAsync(evt.Id, player.Id);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Waiver acceptance required*");
+        (await _context.EventRegistrations.CountAsync(r => r.EventId == evt.Id)).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_AfterAcceptingCurrentWaiver_Succeeds()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+
+        // Act
+        var result = await _sut.RegisterAsync(evt.Id, player.Id);
+
+        // Assert
+        result.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_OrgEventWithoutWaiver_NotGated()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Act
+        var result = await _sut.RegisterAsync(evt.Id, player.Id);
+
+        // Assert
+        result.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ClearedWaiver_NotGated()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "", creator.Id); // Deactivate
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Act
+        var result = await _sut.RegisterAsync(evt.Id, player.Id);
+
+        // Assert
+        result.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_OnlyStaleAcceptance_StillGated()
+    {
+        // Arrange - player accepted v1, admin published v2
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Act
+        var act = () => _sut.RegisterAsync(evt.Id, player.Id);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Waiver acceptance required*");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_StandaloneEvent_NotGated()
+    {
+        // Arrange - standalone events have no org, so no waiver applies
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var evt = await CreateTestEvent(creator.Id, organizationId: null, cost: 0);
+
+        // Act
+        var result = await _sut.RegisterAsync(evt.Id, player.Id);
+
+        // Assert
+        result.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task RegisterAsync_ManagerWithUnacceptedWaiver_AlsoGated()
+    {
+        // Arrange - same rule for everyone with a real account, managers included
+        var creator = await CreateTestUser("creator@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Act
+        var act = () => _sut.RegisterAsync(evt.Id, creator.Id);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Waiver acceptance required*");
+    }
+
+    [Fact]
+    public async Task AddUserToWaitlistAsync_UnacceptedUser_NotGated()
+    {
+        // Arrange - organizer-initiated adds bypass the waiver gate by design
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Act
+        var registration = await _sut.AddUserToWaitlistAsync(evt.Id, player.Id, creator.Id, "Skater");
+
+        // Assert - registration created despite no acceptance
+        registration.Should().NotBeNull();
+        registration.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task CreateGhostPlayerAsync_WithActiveWaiver_NotGated()
+    {
+        // Arrange - ghosts are exempt from everything waiver-related
+        var creator = await CreateTestUser("creator@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Act
+        var registration = await _sut.CreateGhostPlayerAsync(evt.Id, creator.Id, "Ghost", "Goalie", "Goalie", "Bronze");
+
+        // Assert
+        registration.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task CreateAsync_AutoRoster_UnacceptedMembers_StillAdded()
+    {
+        // Arrange - auto-roster is an organizer-initiated path, not gated
+        var creator = await CreateTestUser("creator@example.com");
+        var regular = await CreateTestUser("regular@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        await CreateSubscription(org.Id, regular.Id);
+        await AddAutoRosterMember(org.Id, regular.Id, "Skater", 0);
+
+        // Act
+        var eventDto = await _sut.CreateAsync(CreateEventRequestFor(org.Id), creator.Id);
+
+        // Assert
+        var registration = await _context.EventRegistrations
+            .FirstOrDefaultAsync(r => r.EventId == eventDto.Id && r.UserId == regular.Id);
+        registration.Should().NotBeNull();
+        registration!.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_RequiresWaiverAcceptance_ComputedForCurrentUser()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+
+        // Unaccepted -> true (manager too - same rule for everyone)
+        (await _sut.GetByIdAsync(evt.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeTrue();
+        (await _sut.GetByIdAsync(evt.Id, creator.Id))!.RequiresWaiverAcceptance.Should().BeTrue();
+
+        // Accepted -> false
+        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+        (await _sut.GetByIdAsync(evt.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeFalse();
+
+        // Anonymous -> false
+        (await _sut.GetByIdAsync(evt.Id, null))!.RequiresWaiverAcceptance.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_RequiresWaiverAcceptance_FalseWithoutActiveWaiver()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        var orgEvent = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+        var standaloneEvent = await CreateTestEvent(creator.Id, organizationId: null, cost: 0);
+
+        // No waiver + standalone -> false
+        (await _sut.GetByIdAsync(orgEvent.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeFalse();
+        (await _sut.GetByIdAsync(standaloneEvent.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeFalse();
+
+        // Cleared waiver -> false
+        await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "", creator.Id);
+        (await _sut.GetByIdAsync(orgEvent.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetRegistrationsAsync_HasNotAcceptedWaiver_FlagsOnlyUnacceptedRealUsers()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var accepted = await CreateTestUser("accepted@example.com");
+        var unaccepted = await CreateTestUser("unaccepted@example.com");
+        var ghost = await CreateGhostUser();
+        var org = await CreateTestOrganization(creator.Id);
+        var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+        await CreateRegistration(evt.Id, accepted.Id);
+        await CreateRegistration(evt.Id, unaccepted.Id);
+        await CreateRegistration(evt.Id, ghost.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, accepted.Id);
+
+        // Act
+        var registrations = await _sut.GetRegistrationsAsync(evt.Id);
+
+        // Assert - only the unaccepted real user is flagged; ghost is exempt
+        registrations.Should().HaveCount(3);
+        registrations.Single(r => r.User.Id == accepted.Id).HasNotAcceptedWaiver.Should().BeFalse();
+        registrations.Single(r => r.User.Id == unaccepted.Id).HasNotAcceptedWaiver.Should().BeTrue();
+        registrations.Single(r => r.User.Id == ghost.Id).HasNotAcceptedWaiver.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetRegistrationsAsync_HasNotAcceptedWaiver_AllFalseWithoutActiveWaiver()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
+        await CreateRegistration(evt.Id, player.Id);
+
+        // Act / Assert - no waiver
+        (await _sut.GetRegistrationsAsync(evt.Id)).Should().OnlyContain(r => !r.HasNotAcceptedWaiver);
+
+        // Cleared waiver
+        await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "", creator.Id);
+        (await _sut.GetRegistrationsAsync(evt.Id)).Should().OnlyContain(r => !r.HasNotAcceptedWaiver);
+    }
+
+    [Fact]
+    public async Task GetRegistrationsAsync_HasNotAcceptedWaiver_AllFalseOnStandaloneEvent()
+    {
+        // Arrange
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var evt = await CreateTestEvent(creator.Id, organizationId: null, cost: 0);
+        await CreateRegistration(evt.Id, player.Id);
+
+        // Act / Assert
+        (await _sut.GetRegistrationsAsync(evt.Id)).Should().OnlyContain(r => !r.HasNotAcceptedWaiver);
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -4,6 +4,9 @@ using BHMHockey.Api.Models.Entities;
 using BHMHockey.Api.Services;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
 using Xunit;
 
 namespace BHMHockey.Api.Tests.Services;
@@ -17,16 +20,34 @@ public class OrganizationServiceTests : IDisposable
 {
     private readonly AppDbContext _context;
     private readonly OrganizationAdminService _adminService;
+    private readonly OrganizationWaiverService _waiverService;
+    private readonly Mock<IWaitlistService> _mockWaitlistService;
+    private readonly EventService _eventService;
     private readonly OrganizationService _sut;
 
     public OrganizationServiceTests()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .ConfigureWarnings(w => w.Ignore(InMemoryEventId.TransactionIgnoredWarning))
             .Options;
         _context = new AppDbContext(options);
         _adminService = new OrganizationAdminService(_context);
-        _sut = new OrganizationService(_context, _adminService);
+        _waiverService = new OrganizationWaiverService(_context, _adminService, Mock.Of<ILogger<OrganizationWaiverService>>());
+        _mockWaitlistService = new Mock<IWaitlistService>();
+        _mockWaitlistService.Setup(w => w.GetNextWaitlistPositionAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(1);
+        _mockWaitlistService.Setup(w => w.PromoteFromWaitlistAsync(It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>()))
+            .ReturnsAsync(new PromotionResult());
+        // Real EventService so LeaveAsync composes the standard cancellation path
+        _eventService = new EventService(
+            _context,
+            Mock.Of<INotificationService>(),
+            _adminService,
+            _mockWaitlistService.Object,
+            _waiverService,
+            Mock.Of<ILogger<EventService>>());
+        _sut = new OrganizationService(_context, _adminService, _waiverService, _eventService);
     }
 
     public void Dispose()
@@ -1030,6 +1051,237 @@ public class OrganizationServiceTests : IDisposable
 
         // Assert
         result!.DefaultShowWaitlistBeforePublish.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Leave Organization Tests
+
+    private async Task<Event> CreateOrgEvent(Guid creatorId, Guid orgId, DateTime? eventDate = null, string status = "Published")
+    {
+        var evt = new Event
+        {
+            Id = Guid.NewGuid(),
+            CreatorId = creatorId,
+            OrganizationId = orgId,
+            Name = "Org Event",
+            EventDate = eventDate ?? DateTime.UtcNow.AddDays(7),
+            MaxPlayers = 10,
+            Cost = 0,
+            Status = status,
+            Visibility = "Public"
+        };
+        _context.Events.Add(evt);
+        await _context.SaveChangesAsync();
+        return evt;
+    }
+
+    private async Task<EventRegistration> CreateEventRegistration(Guid eventId, Guid userId, string status = "Registered")
+    {
+        var registration = new EventRegistration
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            UserId = userId,
+            Status = status,
+            RegisteredPosition = "Skater",
+            WaitlistPosition = status == "Waitlisted" ? 1 : null,
+            RegisteredAt = DateTime.UtcNow
+        };
+        _context.EventRegistrations.Add(registration);
+        await _context.SaveChangesAsync();
+        return registration;
+    }
+
+    [Fact]
+    public async Task LeaveAsync_UnsubscribesAndCancelsUpcomingRegistrations()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, member.Id);
+        var upcoming1 = await CreateOrgEvent(creator.Id, org.Id);
+        var upcoming2 = await CreateOrgEvent(creator.Id, org.Id);
+        var reg1 = await CreateEventRegistration(upcoming1.Id, member.Id, "Registered");
+        var reg2 = await CreateEventRegistration(upcoming2.Id, member.Id, "Waitlisted");
+
+        // Act
+        var result = await _sut.LeaveAsync(org.Id, member.Id);
+
+        // Assert
+        result.Should().BeTrue();
+        (await _context.OrganizationSubscriptions
+            .AnyAsync(s => s.OrganizationId == org.Id && s.UserId == member.Id)).Should().BeFalse();
+        (await _context.EventRegistrations.FindAsync(reg1.Id))!.Status.Should().Be("Cancelled");
+        (await _context.EventRegistrations.FindAsync(reg2.Id))!.Status.Should().Be("Cancelled");
+    }
+
+    [Fact]
+    public async Task LeaveAsync_ReusesCancellationPath_FiresPromotionForRegisteredCancellations()
+    {
+        // Arrange - cancelling a REGISTERED spot must go through the standard
+        // promotion side effect (PromoteFromWaitlistAsync), same as a manual cancel
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, member.Id);
+        var evt = await CreateOrgEvent(creator.Id, org.Id);
+        await CreateEventRegistration(evt.Id, member.Id, "Registered");
+
+        // Act
+        await _sut.LeaveAsync(org.Id, member.Id);
+
+        // Assert
+        _mockWaitlistService.Verify(
+            w => w.PromoteFromWaitlistAsync(evt.Id, 1, true),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task LeaveAsync_PastAndCancelledEventRegistrations_Untouched()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, member.Id);
+        var pastEvent = await CreateOrgEvent(creator.Id, org.Id, eventDate: DateTime.UtcNow.AddDays(-3));
+        var cancelledEvent = await CreateOrgEvent(creator.Id, org.Id, status: "Cancelled");
+        var pastReg = await CreateEventRegistration(pastEvent.Id, member.Id, "Registered");
+        var cancelledEventReg = await CreateEventRegistration(cancelledEvent.Id, member.Id, "Registered");
+
+        // Act
+        await _sut.LeaveAsync(org.Id, member.Id);
+
+        // Assert - historical/cancelled-event registrations preserved
+        (await _context.EventRegistrations.FindAsync(pastReg.Id))!.Status.Should().Be("Registered");
+        (await _context.EventRegistrations.FindAsync(cancelledEventReg.Id))!.Status.Should().Be("Registered");
+    }
+
+    [Fact]
+    public async Task LeaveAsync_OtherOrgRegistrations_Untouched()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id, "Org A");
+        var otherOrg = await CreateTestOrganization(creator.Id, "Org B");
+        await CreateSubscription(org.Id, member.Id);
+        await CreateSubscription(otherOrg.Id, member.Id);
+        var otherEvent = await CreateOrgEvent(creator.Id, otherOrg.Id);
+        var otherReg = await CreateEventRegistration(otherEvent.Id, member.Id, "Registered");
+
+        // Act
+        await _sut.LeaveAsync(org.Id, member.Id);
+
+        // Assert
+        (await _context.EventRegistrations.FindAsync(otherReg.Id))!.Status.Should().Be("Registered");
+        (await _context.OrganizationSubscriptions
+            .AnyAsync(s => s.OrganizationId == otherOrg.Id && s.UserId == member.Id)).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task LeaveAsync_NotSubscribedButRegistered_StillCancelsRegistrations()
+    {
+        // Arrange - the blocking gate lists orgs by registration, not subscription,
+        // so leave must work for registered-but-unsubscribed users too
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        var evt = await CreateOrgEvent(creator.Id, org.Id);
+        var reg = await CreateEventRegistration(evt.Id, member.Id, "Registered");
+
+        // Act
+        var result = await _sut.LeaveAsync(org.Id, member.Id);
+
+        // Assert
+        result.Should().BeTrue();
+        (await _context.EventRegistrations.FindAsync(reg.Id))!.Status.Should().Be("Cancelled");
+    }
+
+    #endregion
+
+    #region Member Waiver Status Tests
+
+    [Fact]
+    public async Task GetMembersAsync_NoActiveWaiver_WaiverFlagsAreNull()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, creator.Id);
+        await CreateSubscription(org.Id, member.Id);
+
+        // Act
+        var members = await _sut.GetMembersAsync(org.Id, creator.Id);
+
+        // Assert
+        members.Should().OnlyContain(m => m.HasAcceptedCurrentWaiver == null);
+    }
+
+    [Fact]
+    public async Task GetMembersAsync_ActiveWaiver_FlagsAcceptedAndUnaccepted()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var acceptedMember = await CreateTestUser("accepted@example.com");
+        var unacceptedMember = await CreateTestUser("unaccepted@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, creator.Id);
+        await CreateSubscription(org.Id, acceptedMember.Id);
+        await CreateSubscription(org.Id, unacceptedMember.Id);
+        var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, acceptedMember.Id);
+
+        // Act
+        var members = await _sut.GetMembersAsync(org.Id, creator.Id);
+
+        // Assert
+        members.Single(m => m.Id == acceptedMember.Id).HasAcceptedCurrentWaiver.Should().BeTrue();
+        members.Single(m => m.Id == unacceptedMember.Id).HasAcceptedCurrentWaiver.Should().BeFalse();
+        members.Single(m => m.Id == creator.Id).HasAcceptedCurrentWaiver.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetMembersAsync_ClearedWaiver_WaiverFlagsBackToNull()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, creator.Id);
+        await CreateSubscription(org.Id, member.Id);
+        var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, member.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "", creator.Id);
+
+        // Act
+        var members = await _sut.GetMembersAsync(org.Id, creator.Id);
+
+        // Assert - gating and indicators fully off after clearing
+        members.Should().OnlyContain(m => m.HasAcceptedCurrentWaiver == null);
+    }
+
+    [Fact]
+    public async Task GetMembersAsync_NewVersion_ResetsAcceptanceFlags()
+    {
+        // Arrange
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, creator.Id);
+        await CreateSubscription(org.Id, member.Id);
+        var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, v1!.Id, member.Id);
+        await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
+
+        // Act
+        var members = await _sut.GetMembersAsync(org.Id, creator.Id);
+
+        // Assert - v1 acceptance does not carry over to v2
+        members.Single(m => m.Id == member.Id).HasAcceptedCurrentWaiver.Should().BeFalse();
     }
 
     #endregion

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
@@ -605,5 +605,58 @@ public class OrganizationWaiverServiceTests : IDisposable
         (await _sut.GetCurrentWaiverPdfAsync(org.Id)).Should().BeNull();
     }
 
+    [Fact]
+    public async Task GetCurrentWaiverPdfAsync_WithBoldMarkers_StillRendersPdf()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "**Section 1**\nBody text with **emphasis** and an unmatched ** marker.", admin.Id);
+
+        var result = await _sut.GetCurrentWaiverPdfAsync(org.Id);
+
+        result.Should().NotBeNull();
+        result!.Value.Content.Length.Should().BeGreaterThan(1000);
+        result.Value.Content.Take(4).Should().Equal((byte)'%', (byte)'P', (byte)'D', (byte)'F');
+    }
+
+    #endregion
+
+    #region Bold Segment Parsing
+
+    [Fact]
+    public void ParseBoldSegments_NoMarkers_ReturnsSinglePlainSegment()
+    {
+        OrganizationWaiverService.ParseBoldSegments("Just a waiver.")
+            .Should().Equal(("Just a waiver.", false));
+    }
+
+    [Fact]
+    public void ParseBoldSegments_SinglePair_BoldsMarkedText()
+    {
+        OrganizationWaiverService.ParseBoldSegments("Read **carefully** please")
+            .Should().Equal(("Read ", false), ("carefully", true), (" please", false));
+    }
+
+    [Fact]
+    public void ParseBoldSegments_MultiplePairs_AlternateCorrectly()
+    {
+        OrganizationWaiverService.ParseBoldSegments("**A** and **B**")
+            .Should().Equal(("A", true), (" and ", false), ("B", true));
+    }
+
+    [Fact]
+    public void ParseBoldSegments_UnmatchedTrailingMarker_RendersLiterally()
+    {
+        OrganizationWaiverService.ParseBoldSegments("Signed **here and more text")
+            .Should().Equal(("Signed ", false), ("**here and more text", false));
+    }
+
+    [Fact]
+    public void ParseBoldSegments_BoldSpanningNewline_Preserved()
+    {
+        OrganizationWaiverService.ParseBoldSegments("**Section 1**\nBody")
+            .Should().Equal(("Section 1", true), ("\nBody", false));
+    }
+
     #endregion
 }

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
@@ -1,0 +1,609 @@
+using BHMHockey.Api.Data;
+using BHMHockey.Api.Models.Entities;
+using BHMHockey.Api.Services;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace BHMHockey.Api.Tests.Services;
+
+/// <summary>
+/// Tests for OrganizationWaiverService - protecting the legal waiver rules:
+/// - Versions are immutable and per-org incrementing (audit trail)
+/// - "Active waiver" = latest version row IF its text is non-empty
+/// - Acceptances are idempotent and stale versions are rejected
+/// - Pending waivers cover only upcoming, non-cancelled org events
+/// </summary>
+public class OrganizationWaiverServiceTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly OrganizationAdminService _adminService;
+    private readonly OrganizationWaiverService _sut;
+
+    public OrganizationWaiverServiceTests()
+    {
+        // QuestPDF requires a license selection before rendering (set in Program.cs at runtime)
+        QuestPDF.Settings.License = QuestPDF.Infrastructure.LicenseType.Community;
+
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+        _adminService = new OrganizationAdminService(_context);
+        _sut = new OrganizationWaiverService(_context, _adminService, Mock.Of<ILogger<OrganizationWaiverService>>());
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    #region Helper Methods
+
+    private async Task<User> CreateTestUser(string email = "test@example.com", bool isGhost = false)
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            PasswordHash = "hashed_password",
+            FirstName = "Test",
+            LastName = "User",
+            Positions = new Dictionary<string, string> { { "skater", "Silver" } },
+            Role = "Player",
+            IsActive = true,
+            IsGhostPlayer = isGhost,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+        return user;
+    }
+
+    private async Task<Organization> CreateTestOrganization(Guid creatorId, string name = "Test Org", bool isActive = true)
+    {
+        var org = new Organization
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            CreatorId = creatorId,
+            IsActive = isActive,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _context.Organizations.Add(org);
+        _context.OrganizationAdmins.Add(new OrganizationAdmin
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = org.Id,
+            UserId = creatorId,
+            AddedAt = DateTime.UtcNow,
+            AddedByUserId = null
+        });
+
+        await _context.SaveChangesAsync();
+        return org;
+    }
+
+    private async Task<Event> CreateTestEvent(
+        Guid creatorId,
+        Guid? organizationId,
+        DateTime? eventDate = null,
+        string status = "Published")
+    {
+        var evt = new Event
+        {
+            Id = Guid.NewGuid(),
+            CreatorId = creatorId,
+            OrganizationId = organizationId,
+            Name = "Test Event",
+            EventDate = eventDate ?? DateTime.UtcNow.AddDays(7),
+            MaxPlayers = 10,
+            Cost = 0,
+            Status = status,
+            Visibility = "Public"
+        };
+
+        _context.Events.Add(evt);
+        await _context.SaveChangesAsync();
+        return evt;
+    }
+
+    private async Task<EventRegistration> CreateRegistration(Guid eventId, Guid userId, string status = "Registered")
+    {
+        var registration = new EventRegistration
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            UserId = userId,
+            Status = status,
+            RegisteredPosition = "Skater",
+            WaitlistPosition = status == "Waitlisted" ? 1 : null
+        };
+
+        _context.EventRegistrations.Add(registration);
+        await _context.SaveChangesAsync();
+        return registration;
+    }
+
+    #endregion
+
+    #region SetWaiver / Versioning Tests
+
+    [Fact]
+    public async Task SetWaiverAsync_FirstSave_CreatesVersion1()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+
+        var result = await _sut.SetWaiverAsync(org.Id, "You play at your own risk.", admin.Id);
+
+        result.Should().NotBeNull();
+        result!.Version.Should().Be(1);
+        result.Text.Should().Be("You play at your own risk.");
+        result.OrganizationId.Should().Be(org.Id);
+    }
+
+    [Fact]
+    public async Task SetWaiverAsync_Edit_CreatesNewRowAndLeavesOldRowUntouched()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+        var v1 = await _sut.SetWaiverAsync(org.Id, "Version one text", admin.Id);
+
+        var v2 = await _sut.SetWaiverAsync(org.Id, "Version two text", admin.Id);
+
+        v2!.Version.Should().Be(2);
+        v2.Id.Should().NotBe(v1!.Id);
+
+        // Immutability: the v1 row still exists with byte-identical text
+        var rows = await _context.OrganizationWaivers
+            .Where(w => w.OrganizationId == org.Id)
+            .OrderBy(w => w.Version)
+            .ToListAsync();
+        rows.Should().HaveCount(2);
+        rows[0].Id.Should().Be(v1.Id);
+        rows[0].Text.Should().Be("Version one text");
+        rows[0].Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SetWaiverAsync_TrimsText()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+
+        var result = await _sut.SetWaiverAsync(org.Id, "   padded text \n ", admin.Id);
+
+        result!.Text.Should().Be("padded text");
+    }
+
+    [Fact]
+    public async Task SetWaiverAsync_VersionsIncrementPerOrg()
+    {
+        var admin = await CreateTestUser();
+        var orgA = await CreateTestOrganization(admin.Id, "Org A");
+        var orgB = await CreateTestOrganization(admin.Id, "Org B");
+
+        await _sut.SetWaiverAsync(orgA.Id, "A v1", admin.Id);
+        await _sut.SetWaiverAsync(orgA.Id, "A v2", admin.Id);
+        var bResult = await _sut.SetWaiverAsync(orgB.Id, "B v1", admin.Id);
+
+        // Org B starts at version 1 regardless of org A's history
+        bResult!.Version.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SetWaiverAsync_NonAdmin_ThrowsUnauthorized()
+    {
+        var admin = await CreateTestUser();
+        var nonAdmin = await CreateTestUser("other@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+
+        var act = () => _sut.SetWaiverAsync(org.Id, "text", nonAdmin.Id);
+
+        await act.Should().ThrowAsync<UnauthorizedAccessException>();
+        (await _context.OrganizationWaivers.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SetWaiverAsync_EmptyText_CreatesDeactivatingVersionAndPreservesHistory()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "Some waiver", admin.Id);
+
+        var result = await _sut.SetWaiverAsync(org.Id, "   ", admin.Id);
+
+        result.Should().BeNull(); // No active waiver after clearing
+        var rows = await _context.OrganizationWaivers
+            .Where(w => w.OrganizationId == org.Id)
+            .OrderBy(w => w.Version)
+            .ToListAsync();
+        rows.Should().HaveCount(2);
+        rows[0].Text.Should().Be("Some waiver"); // History preserved
+        rows[1].Text.Should().Be("");
+        rows[1].Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SetWaiverAsync_EmptyTextWithNoExistingWaiver_IsNoOp()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+
+        var result = await _sut.SetWaiverAsync(org.Id, "", admin.Id);
+
+        result.Should().BeNull();
+        (await _context.OrganizationWaivers.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task SetWaiverAsync_IdenticalText_DoesNotCreateNewVersion()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+        var v1 = await _sut.SetWaiverAsync(org.Id, "Same text", admin.Id);
+
+        var result = await _sut.SetWaiverAsync(org.Id, "Same text", admin.Id);
+
+        result!.Id.Should().Be(v1!.Id);
+        result.Version.Should().Be(1);
+        (await _context.OrganizationWaivers.CountAsync()).Should().Be(1);
+    }
+
+    #endregion
+
+    #region Active Waiver Semantics
+
+    [Fact]
+    public async Task GetCurrentWaiverAsync_NoWaiver_ReturnsNull()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+
+        var result = await _sut.GetCurrentWaiverAsync(org.Id);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentWaiverAsync_ReturnsLatestVersion()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var v2 = await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
+
+        var result = await _sut.GetCurrentWaiverAsync(org.Id);
+
+        result!.Id.Should().Be(v2!.Id);
+        result.Version.Should().Be(2);
+        result.Text.Should().Be("v2");
+    }
+
+    [Fact]
+    public async Task GetCurrentWaiverAsync_ClearedWaiver_ReturnsNull()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "", admin.Id);
+
+        var result = await _sut.GetCurrentWaiverAsync(org.Id);
+
+        result.Should().BeNull();
+        (await _sut.GetActiveWaiverIdAsync(org.Id)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task IsAcceptanceRequiredAsync_TracksActiveWaiverAndAcceptance()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+
+        // No waiver -> not required
+        (await _sut.IsAcceptanceRequiredAsync(org.Id, player.Id)).Should().BeFalse();
+
+        // Active waiver, not accepted -> required
+        var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        (await _sut.IsAcceptanceRequiredAsync(org.Id, player.Id)).Should().BeTrue();
+
+        // Accepted -> not required
+        await _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+        (await _sut.IsAcceptanceRequiredAsync(org.Id, player.Id)).Should().BeFalse();
+
+        // New version -> required again
+        await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
+        (await _sut.IsAcceptanceRequiredAsync(org.Id, player.Id)).Should().BeTrue();
+
+        // Cleared -> not required
+        await _sut.SetWaiverAsync(org.Id, "", admin.Id);
+        (await _sut.IsAcceptanceRequiredAsync(org.Id, player.Id)).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Acceptance Tests
+
+    [Fact]
+    public async Task AcceptWaiverAsync_RecordsAcceptance()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        await _sut.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+
+        var acceptance = await _context.WaiverAcceptances
+            .FirstOrDefaultAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
+        acceptance.Should().NotBeNull();
+        acceptance!.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(1));
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_AlreadyAccepted_IsIdempotent()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        await _sut.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, waiver.Id, player.Id); // No throw
+
+        (await _context.WaiverAcceptances.CountAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id))
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_StaleVersion_Throws()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*no longer current*");
+        (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_ClearedWaiver_Throws()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_WaiverFromDifferentOrg_Throws()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var orgA = await CreateTestOrganization(admin.Id, "Org A");
+        var orgB = await CreateTestOrganization(admin.Id, "Org B");
+        var waiverA = await _sut.SetWaiverAsync(orgA.Id, "A v1", admin.Id);
+        await _sut.SetWaiverAsync(orgB.Id, "B v1", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(orgB.Id, waiverA!.Id, player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    #endregion
+
+    #region Pending Waivers Tests
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_ListsOrgWithUnacceptedWaiverOnUpcomingEvent()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id, "Waiver Org");
+        var waiver = await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        var evt = await CreateTestEvent(admin.Id, org.Id);
+        await CreateRegistration(evt.Id, player.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().HaveCount(1);
+        pending[0].OrganizationId.Should().Be(org.Id);
+        pending[0].OrganizationName.Should().Be("Waiver Org");
+        pending[0].Waiver.Id.Should().Be(waiver!.Id);
+        pending[0].Waiver.Text.Should().Be("waiver text");
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_WaitlistedRegistrationCounts()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        var evt = await CreateTestEvent(admin.Id, org.Id);
+        await CreateRegistration(evt.Id, player.Id, status: "Waitlisted");
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_AcceptedUser_NotListed()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        var evt = await CreateTestEvent(admin.Id, org.Id);
+        await CreateRegistration(evt.Id, player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_NewVersionAfterAcceptance_ListedAgain()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var evt = await CreateTestEvent(admin.Id, org.Id);
+        await CreateRegistration(evt.Id, player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+
+        var v2 = await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().HaveCount(1);
+        pending[0].Waiver.Id.Should().Be(v2!.Id);
+        pending[0].Waiver.Version.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_PastEvent_Excluded()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        var pastEvent = await CreateTestEvent(admin.Id, org.Id, eventDate: DateTime.UtcNow.AddDays(-2));
+        await CreateRegistration(pastEvent.Id, player.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_CancelledEvent_Excluded()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        var cancelledEvent = await CreateTestEvent(admin.Id, org.Id, status: "Cancelled");
+        await CreateRegistration(cancelledEvent.Id, player.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_CancelledRegistration_Excluded()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        var evt = await CreateTestEvent(admin.Id, org.Id);
+        await CreateRegistration(evt.Id, player.Id, status: "Cancelled");
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_NoActiveWaiver_Excluded()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "", admin.Id); // Cleared
+        var evt = await CreateTestEvent(admin.Id, org.Id);
+        await CreateRegistration(evt.Id, player.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_StandaloneEvent_Excluded()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var standaloneEvent = await CreateTestEvent(admin.Id, organizationId: null);
+        await CreateRegistration(standaloneEvent.Id, player.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_MultipleEventsSameOrg_ListedOnce()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        var evt1 = await CreateTestEvent(admin.Id, org.Id);
+        var evt2 = await CreateTestEvent(admin.Id, org.Id);
+        await CreateRegistration(evt1.Id, player.Id);
+        await CreateRegistration(evt2.Id, player.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(player.Id);
+
+        pending.Should().HaveCount(1);
+    }
+
+    #endregion
+
+    #region PDF Tests
+
+    [Fact]
+    public async Task GetCurrentWaiverPdfAsync_ActiveWaiver_ReturnsPdfBytes()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id, "PDF Test Org");
+        await _sut.SetWaiverAsync(org.Id, "This is the waiver body text used to render the PDF.", admin.Id);
+
+        var result = await _sut.GetCurrentWaiverPdfAsync(org.Id);
+
+        result.Should().NotBeNull();
+        result!.Value.Content.Length.Should().BeGreaterThan(1000); // A real PDF, not a stub
+        // PDF magic bytes: %PDF
+        result.Value.Content.Take(4).Should().Equal((byte)'%', (byte)'P', (byte)'D', (byte)'F');
+        result.Value.FileName.Should().Be("pdf-test-org-waiver-v1.pdf");
+    }
+
+    [Fact]
+    public async Task GetCurrentWaiverPdfAsync_NoActiveWaiver_ReturnsNull()
+    {
+        var admin = await CreateTestUser();
+        var org = await CreateTestOrganization(admin.Id);
+
+        (await _sut.GetCurrentWaiverPdfAsync(org.Id)).Should().BeNull();
+
+        // Cleared waiver also returns null
+        await _sut.SetWaiverAsync(org.Id, "text", admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "", admin.Id);
+        (await _sut.GetCurrentWaiverPdfAsync(org.Id)).Should().BeNull();
+    }
+
+    #endregion
+}

--- a/apps/api/BHMHockey.Api/BHMHockey.Api.csproj
+++ b/apps/api/BHMHockey.Api/BHMHockey.Api.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <!-- ASP.NET Core -->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="QuestPDF" Version="2024.12.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 
     <!-- Entity Framework Core -->

--- a/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
@@ -13,17 +13,20 @@ public class OrganizationsController : ControllerBase
     private readonly IOrganizationService _organizationService;
     private readonly IOrganizationAdminService _adminService;
     private readonly IOrganizationAutoRosterService _autoRosterService;
+    private readonly IOrganizationWaiverService _waiverService;
     private readonly ILogger<OrganizationsController> _logger;
 
     public OrganizationsController(
         IOrganizationService organizationService,
         IOrganizationAdminService adminService,
         IOrganizationAutoRosterService autoRosterService,
+        IOrganizationWaiverService waiverService,
         ILogger<OrganizationsController> logger)
     {
         _organizationService = organizationService;
         _adminService = adminService;
         _autoRosterService = autoRosterService;
+        _waiverService = waiverService;
         _logger = logger;
     }
 
@@ -221,6 +224,107 @@ public class OrganizationsController : ControllerBase
         }
 
         return NoContent();
+    }
+
+    /// <summary>
+    /// Leave an organization: unsubscribe AND cancel upcoming registrations in the
+    /// org's events (waitlist promotions fire as usual). Requires authentication.
+    /// </summary>
+    [HttpPost("{id:guid}/leave")]
+    [Authorize]
+    public async Task<IActionResult> Leave(Guid id)
+    {
+        var userId = GetCurrentUserId();
+        await _organizationService.LeaveAsync(id, userId);
+        return Ok(new { message = "You have left the organization" });
+    }
+
+    // Waiver endpoints
+
+    /// <summary>
+    /// Get the organization's current active waiver. 404 when no active waiver.
+    /// </summary>
+    [HttpGet("{id:guid}/waiver")]
+    [Authorize]
+    public async Task<ActionResult<OrganizationWaiverDto>> GetWaiver(Guid id)
+    {
+        var waiver = await _waiverService.GetCurrentWaiverAsync(id);
+
+        if (waiver == null)
+        {
+            return NotFound(new { message = "This organization has no active waiver" });
+        }
+
+        return Ok(waiver);
+    }
+
+    /// <summary>
+    /// Set the organization's waiver (admin only). Creates the next immutable
+    /// version from the submitted text; empty text deactivates the waiver.
+    /// </summary>
+    [HttpPut("{id:guid}/waiver")]
+    [Authorize]
+    public async Task<ActionResult<SetOrganizationWaiverResponse>> SetWaiver(Guid id, [FromBody] SetOrganizationWaiverRequest request)
+    {
+        var userId = GetCurrentUserId();
+
+        try
+        {
+            var waiver = await _waiverService.SetWaiverAsync(id, request.Text, userId);
+            return Ok(new SetOrganizationWaiverResponse(waiver));
+        }
+        catch (UnauthorizedAccessException)
+        {
+            _logger.LogWarning("Set waiver denied for organization {OrganizationId}: requester is not an admin", id);
+            return Forbid();
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Set waiver rejected for organization {OrganizationId}: {Message}", id, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Render the organization's current waiver as a PDF. Public by design -
+    /// waivers aren't secrets and users save/share them outside the app.
+    /// 404 when no active waiver.
+    /// </summary>
+    [HttpGet("{id:guid}/waiver/pdf")]
+    [AllowAnonymous]
+    public async Task<IActionResult> GetWaiverPdf(Guid id)
+    {
+        var pdf = await _waiverService.GetCurrentWaiverPdfAsync(id);
+
+        if (pdf == null)
+        {
+            _logger.LogWarning("Waiver PDF requested for organization {OrganizationId} with no active waiver", id);
+            return NotFound(new { message = "This organization has no active waiver" });
+        }
+
+        return File(pdf.Value.Content, "application/pdf", pdf.Value.FileName);
+    }
+
+    /// <summary>
+    /// Accept a SPECIFIC waiver version. 400 when the id is not the org's current
+    /// active version (stale-version protection). Idempotent when already accepted.
+    /// </summary>
+    [HttpPost("{id:guid}/waiver/accept")]
+    [Authorize]
+    public async Task<IActionResult> AcceptWaiver(Guid id, [FromBody] AcceptWaiverRequest request)
+    {
+        var userId = GetCurrentUserId();
+
+        try
+        {
+            await _waiverService.AcceptWaiverAsync(id, request.WaiverId, userId);
+            return Ok(new { message = "Waiver accepted" });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Waiver acceptance rejected for organization {OrganizationId}: {Message}", id, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     // Admin management endpoints

--- a/apps/api/BHMHockey.Api/Controllers/UsersController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/UsersController.cs
@@ -17,6 +17,7 @@ public class UsersController : ControllerBase
     private readonly IBadgeService _badgeService;
     private readonly ITournamentTeamMemberService _tournamentTeamMemberService;
     private readonly ITournamentService _tournamentService;
+    private readonly IOrganizationWaiverService _waiverService;
 
     public UsersController(
         IUserService userService,
@@ -24,7 +25,8 @@ public class UsersController : ControllerBase
         IEventService eventService,
         IBadgeService badgeService,
         ITournamentTeamMemberService tournamentTeamMemberService,
-        ITournamentService tournamentService)
+        ITournamentService tournamentService,
+        IOrganizationWaiverService waiverService)
     {
         _userService = userService;
         _organizationService = organizationService;
@@ -32,6 +34,7 @@ public class UsersController : ControllerBase
         _badgeService = badgeService;
         _tournamentTeamMemberService = tournamentTeamMemberService;
         _tournamentService = tournamentService;
+        _waiverService = waiverService;
     }
 
     private Guid GetCurrentUserId()
@@ -167,6 +170,26 @@ public class UsersController : ControllerBase
         catch (InvalidOperationException ex)
         {
             return BadRequest(new { message = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Orgs where the current user holds an active registration on an upcoming
+    /// event but has not accepted the org's current waiver. Powers the blocking
+    /// accept-or-leave gate shown on app open/foreground.
+    /// </summary>
+    [HttpGet("me/pending-waivers")]
+    public async Task<ActionResult<List<PendingWaiverDto>>> GetMyPendingWaivers()
+    {
+        try
+        {
+            var userId = GetCurrentUserId();
+            var pending = await _waiverService.GetPendingWaiversAsync(userId);
+            return Ok(pending);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return Unauthorized(new { message = ex.Message });
         }
     }
 

--- a/apps/api/BHMHockey.Api/Data/AppDbContext.cs
+++ b/apps/api/BHMHockey.Api/Data/AppDbContext.cs
@@ -18,6 +18,8 @@ public class AppDbContext : DbContext
     public DbSet<OrganizationSubscription> OrganizationSubscriptions { get; set; }
     public DbSet<OrganizationAdmin> OrganizationAdmins { get; set; }
     public DbSet<OrganizationAutoRosterMember> OrganizationAutoRosterMembers { get; set; }
+    public DbSet<OrganizationWaiver> OrganizationWaivers { get; set; }
+    public DbSet<WaiverAcceptance> WaiverAcceptances { get; set; }
     public DbSet<Event> Events { get; set; }
     public DbSet<EventRegistration> EventRegistrations { get; set; }
     public DbSet<Notification> Notifications { get; set; }
@@ -158,6 +160,48 @@ public class AppDbContext : DbContext
                 .WithMany()
                 .HasForeignKey(e => e.AddedByUserId)
                 .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // OrganizationWaiver configuration - immutable version rows (legal audit trail)
+        modelBuilder.Entity<OrganizationWaiver>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Text).IsRequired();
+
+            // One row per (org, version); latest version is the current waiver
+            entity.HasIndex(e => new { e.OrganizationId, e.Version }).IsUnique();
+
+            entity.HasOne(e => e.Organization)
+                .WithMany()
+                .HasForeignKey(e => e.OrganizationId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(e => e.CreatedByUser)
+                .WithMany()
+                .HasForeignKey(e => e.CreatedByUserId)
+                .OnDelete(DeleteBehavior.SetNull);
+        });
+
+        // WaiverAcceptance configuration - user accepted a specific waiver version
+        modelBuilder.Entity<WaiverAcceptance>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+
+            // A user accepts each waiver version at most once
+            entity.HasIndex(e => new { e.UserId, e.WaiverId }).IsUnique();
+
+            // Index for "who accepted this version" queries (roster/member flags)
+            entity.HasIndex(e => e.WaiverId);
+
+            entity.HasOne(e => e.User)
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasOne(e => e.Waiver)
+                .WithMany()
+                .HasForeignKey(e => e.WaiverId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         // Event configuration

--- a/apps/api/BHMHockey.Api/Migrations/20260717160800_AddOrganizationWaivers.Designer.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717160800_AddOrganizationWaivers.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BHMHockey.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHMHockey.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260717160800_AddOrganizationWaivers")]
+    partial class AddOrganizationWaivers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/BHMHockey.Api/Migrations/20260717160800_AddOrganizationWaivers.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260717160800_AddOrganizationWaivers.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHMHockey.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrganizationWaivers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OrganizationWaivers",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    OrganizationId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Text = table.Column<string>(type: "text", nullable: false),
+                    Version = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    CreatedByUserId = table.Column<Guid>(type: "uuid", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizationWaivers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrganizationWaivers_Organizations_OrganizationId",
+                        column: x => x.OrganizationId,
+                        principalTable: "Organizations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_OrganizationWaivers_Users_CreatedByUserId",
+                        column: x => x.CreatedByUserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "WaiverAcceptances",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    WaiverId = table.Column<Guid>(type: "uuid", nullable: false),
+                    AcceptedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WaiverAcceptances", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_WaiverAcceptances_OrganizationWaivers_WaiverId",
+                        column: x => x.WaiverId,
+                        principalTable: "OrganizationWaivers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_WaiverAcceptances_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationWaivers_CreatedByUserId",
+                table: "OrganizationWaivers",
+                column: "CreatedByUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrganizationWaivers_OrganizationId_Version",
+                table: "OrganizationWaivers",
+                columns: new[] { "OrganizationId", "Version" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WaiverAcceptances_UserId_WaiverId",
+                table: "WaiverAcceptances",
+                columns: new[] { "UserId", "WaiverId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WaiverAcceptances_WaiverId",
+                table: "WaiverAcceptances",
+                column: "WaiverId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WaiverAcceptances");
+
+            migrationBuilder.DropTable(
+                name: "OrganizationWaivers");
+        }
+    }
+}

--- a/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
@@ -42,7 +42,10 @@ public record EventDto(
     // Waitlist visibility (pre-publish)
     bool ShowWaitlistBeforePublish = false,  // Registered/waitlisted viewers can see the ordered waitlist before publish
     // Pay-eligibility for the current user's waitlisted registration on paid events
-    bool? MyWaitlistPaymentEligible = null   // null when not applicable (not waitlisted or free event)
+    bool? MyWaitlistPaymentEligible = null,  // null when not applicable (not waitlisted or free event)
+    // Waiver gate for the current user: org event + active waiver + not accepted
+    // (same rule for everyone with a real account, including managers)
+    bool RequiresWaiverAcceptance = false
 );
 
 public record CreateEventRequest(
@@ -99,7 +102,9 @@ public record EventRegistrationDto(
     int? WaitlistPosition,       // Position in waitlist (1 = first, null = not waitlisted)
     DateTime? PromotedAt,        // When user was promoted from waitlist
     DateTime? PaymentDeadlineAt, // Deadline to pay after promotion
-    bool IsWaitlisted            // True if Status == "Waitlisted"
+    bool IsWaitlisted,           // True if Status == "Waitlisted"
+    // True ONLY when: org event + active waiver + real user (not ghost) + no current acceptance
+    bool HasNotAcceptedWaiver = false
 );
 
 // Payment request DTOs (Phase 4)

--- a/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/OrganizationDTOs.cs
@@ -33,7 +33,8 @@ public record OrganizationMemberDto(
     DateTime SubscribedAt,
     bool IsAdmin,  // True if this member is an admin of the organization
     List<UserBadgeDto>? Badges = null,  // Top 3 badges by displayOrder
-    int TotalBadgeCount = 0  // Total badges user has earned
+    int TotalBadgeCount = 0,  // Total badges user has earned
+    bool? HasAcceptedCurrentWaiver = null  // null when the org has no active waiver
 );
 
 public record CreateOrganizationRequest(

--- a/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
@@ -1,0 +1,33 @@
+namespace BHMHockey.Api.Models.DTOs;
+
+// A single (immutable) waiver version
+public record OrganizationWaiverDto(
+    Guid Id,
+    Guid OrganizationId,
+    string Text,
+    int Version,
+    DateTime CreatedAt
+);
+
+// PUT waiver request - trimmed server-side; empty text deactivates the waiver
+public record SetOrganizationWaiverRequest(
+    string? Text
+);
+
+// PUT waiver response - Waiver is null when no active waiver remains (cleared)
+public record SetOrganizationWaiverResponse(
+    OrganizationWaiverDto? Waiver
+);
+
+// Accept a SPECIFIC waiver version (stale ids are rejected with 400)
+public record AcceptWaiverRequest(
+    Guid WaiverId
+);
+
+// Blocking-gate entry: an org where the current user holds an upcoming
+// registration but has not accepted the current active waiver
+public record PendingWaiverDto(
+    Guid OrganizationId,
+    string OrganizationName,
+    OrganizationWaiverDto Waiver
+);

--- a/apps/api/BHMHockey.Api/Models/Entities/OrganizationWaiver.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/OrganizationWaiver.cs
@@ -1,0 +1,21 @@
+namespace BHMHockey.Api.Models.Entities;
+
+/// <summary>
+/// A single immutable version of an organization's legal waiver.
+/// Editing the waiver always creates a NEW row with the next version number;
+/// rows are never updated or deleted so we can prove exactly what text any
+/// user accepted (legal audit trail). The "active" waiver is the org's latest
+/// version row IF its Text is non-empty - saving an empty text creates a new
+/// version that deactivates the waiver while preserving history.
+/// </summary>
+public class OrganizationWaiver
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid OrganizationId { get; set; }
+    public Organization Organization { get; set; } = null!;
+    public string Text { get; set; } = string.Empty;
+    public int Version { get; set; }  // Per-org incrementing, starting at 1
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public Guid? CreatedByUserId { get; set; }
+    public User? CreatedByUser { get; set; }
+}

--- a/apps/api/BHMHockey.Api/Models/Entities/WaiverAcceptance.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/WaiverAcceptance.cs
@@ -1,0 +1,16 @@
+namespace BHMHockey.Api.Models.Entities;
+
+/// <summary>
+/// Records that a user accepted a SPECIFIC waiver version (OrganizationWaivers row).
+/// A new waiver version requires a new acceptance; old acceptances are kept as
+/// part of the legal audit trail.
+/// </summary>
+public class WaiverAcceptance
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+    public Guid WaiverId { get; set; }
+    public OrganizationWaiver Waiver { get; set; } = null!;
+    public DateTime AcceptedAt { get; set; } = DateTime.UtcNow;
+}

--- a/apps/api/BHMHockey.Api/Program.cs
+++ b/apps/api/BHMHockey.Api/Program.cs
@@ -9,6 +9,9 @@ using BHMHockey.Api.Services.Background;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// QuestPDF (waiver PDF rendering) - community license for open/small projects
+QuestPDF.Settings.License = QuestPDF.Infrastructure.LicenseType.Community;
+
 // Configure for network access (React Native development)
 // Production uses ASPNETCORE_URLS from app.yaml (port 8080)
 if (builder.Environment.IsDevelopment())
@@ -127,6 +130,7 @@ builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<IOrganizationService, OrganizationService>();
 builder.Services.AddScoped<IOrganizationAdminService, OrganizationAdminService>();
 builder.Services.AddScoped<IOrganizationAutoRosterService, OrganizationAutoRosterService>();
+builder.Services.AddScoped<IOrganizationWaiverService, OrganizationWaiverService>();
 builder.Services.AddScoped<IEventService, EventService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddScoped<IWaitlistService, WaitlistService>();

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -12,6 +12,7 @@ public class EventService : IEventService
     private readonly INotificationService _notificationService;
     private readonly IOrganizationAdminService _adminService;
     private readonly IWaitlistService _waitlistService;
+    private readonly IOrganizationWaiverService _waiverService;
     private readonly ILogger<EventService> _logger;
     private static readonly HashSet<string> ValidSkillLevels = new() { "Gold", "Silver", "Bronze", "D-League" };
 
@@ -23,12 +24,14 @@ public class EventService : IEventService
         INotificationService notificationService,
         IOrganizationAdminService adminService,
         IWaitlistService waitlistService,
+        IOrganizationWaiverService waiverService,
         ILogger<EventService> logger)
     {
         _context = context;
         _notificationService = notificationService;
         _adminService = adminService;
         _waitlistService = waitlistService;
+        _waiverService = waiverService;
         _logger = logger;
     }
 
@@ -491,6 +494,17 @@ public class EventService : IEventService
             throw new InvalidOperationException("Already registered for this event");
         }
 
+        // Self-registration waiver gate: org events with an active waiver require the
+        // CURRENT version to be accepted first. Organizer-driven paths (auto-roster,
+        // manual add, ghost creation) are intentionally NOT gated - the blocking
+        // accept-or-leave gate catches those users in the app. Ghosts are exempt.
+        if (evt.OrganizationId.HasValue && !user.IsGhostPlayer &&
+            await _waiverService.IsAcceptanceRequiredAsync(evt.OrganizationId.Value, userId))
+        {
+            _logger.LogWarning("Registration blocked for event {EventId}: user {UserId} has not accepted the organization's current waiver", eventId, userId);
+            throw new InvalidOperationException("Waiver acceptance required: you must accept this organization's current waiver before registering for this event.");
+        }
+
         // Goalies don't count against MaxPlayers - only skaters do
         var skaterCount = evt.Registrations.Count(r => r.Status == "Registered" && r.RegisteredPosition != "Goalie");
         bool isFull = registeredPosition == "Goalie" ? false : skaterCount >= evt.MaxPlayers;
@@ -743,6 +757,9 @@ public class EventService : IEventService
         var userIds = registrations.Select(r => r.User.Id).Distinct();
         var badgesByUser = await GetBadgesForUsersAsync(userIds);
 
+        // Batch compute which real users still need to accept the org's active waiver
+        var waiverUnaccepted = await GetWaiverUnacceptedUserIdsAsync(eventId, registrations);
+
         return registrations.Select(r => {
             var (topBadges, totalCount) = badgesByUser.TryGetValue(r.User.Id, out var badges)
                 ? badges
@@ -776,7 +793,8 @@ public class EventService : IEventService
                 r.WaitlistPosition,     // Phase 5 - Waitlist
                 r.PromotedAt,           // Phase 5 - Waitlist
                 r.PaymentDeadlineAt,    // Phase 5 - Waitlist
-                r.IsWaitlisted          // Phase 5 - Waitlist
+                r.IsWaitlisted,         // Phase 5 - Waitlist
+                waiverUnaccepted.Contains(r.UserId)  // Waiver indicator (real users only)
             );
         }).ToList();
     }
@@ -788,6 +806,9 @@ public class EventService : IEventService
         // Batch load badges for all users to prevent N+1 queries
         var userIds = waitlist.Select(r => r.User.Id).Distinct();
         var badgesByUser = await GetBadgesForUsersAsync(userIds);
+
+        // Batch compute which real users still need to accept the org's active waiver
+        var waiverUnaccepted = await GetWaiverUnacceptedUserIdsAsync(eventId, waitlist);
 
         return waitlist.Select(r => {
             var (topBadges, totalCount) = badgesByUser.TryGetValue(r.User.Id, out var badges)
@@ -822,9 +843,50 @@ public class EventService : IEventService
                 r.WaitlistPosition,
                 r.PromotedAt,
                 r.PaymentDeadlineAt,
-                r.IsWaitlisted
+                r.IsWaitlisted,
+                waiverUnaccepted.Contains(r.UserId)  // Waiver indicator (real users only)
             );
         }).ToList();
+    }
+
+    /// <summary>
+    /// User ids on this event that should show the "has not accepted waiver" flag:
+    /// real (non-ghost) users without an acceptance of the org's ACTIVE waiver.
+    /// Empty when the event is standalone or the org has no active waiver.
+    /// </summary>
+    private async Task<HashSet<Guid>> GetWaiverUnacceptedUserIdsAsync(Guid eventId, IEnumerable<EventRegistration> registrations)
+    {
+        var organizationId = await _context.Events
+            .Where(e => e.Id == eventId)
+            .Select(e => e.OrganizationId)
+            .FirstOrDefaultAsync();
+        if (!organizationId.HasValue)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var activeWaiverId = await _waiverService.GetActiveWaiverIdAsync(organizationId.Value);
+        if (!activeWaiverId.HasValue)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var realUserIds = registrations
+            .Where(r => !r.User.IsGhostPlayer)
+            .Select(r => r.UserId)
+            .Distinct()
+            .ToList();
+        if (realUserIds.Count == 0)
+        {
+            return new HashSet<Guid>();
+        }
+
+        var acceptedIds = await _context.WaiverAcceptances
+            .Where(a => a.WaiverId == activeWaiverId.Value && realUserIds.Contains(a.UserId))
+            .Select(a => a.UserId)
+            .ToListAsync();
+
+        return realUserIds.Except(acceptedIds).ToHashSet();
     }
 
     /// <summary>
@@ -1006,6 +1068,14 @@ public class EventService : IEventService
             }
         }
 
+        // Waiver gate flag for the current user: org event + active waiver + not
+        // accepted. Same rule for everyone with a real account, managers included.
+        var requiresWaiverAcceptance = false;
+        if (currentUserId.HasValue && evt.OrganizationId.HasValue)
+        {
+            requiresWaiverAcceptance = await _waiverService.IsAcceptanceRequiredAsync(evt.OrganizationId.Value, currentUserId.Value);
+        }
+
         // Resolve chat link at read time: event override wins, else the org's link (live fallback,
         // so rotating the org link updates all inheriting events instantly)
         string? groupMeLink = null;
@@ -1058,7 +1128,8 @@ public class EventService : IEventService
             groupMeLink,         // Resolved GroupMe chat link
             groupMeLinkSource,   // "event" | "organization" | null
             evt.ShowWaitlistBeforePublish,  // Waitlist visibility (pre-publish)
-            myWaitlistPaymentEligible       // Pay-eligibility for current user's waitlisted spot
+            myWaitlistPaymentEligible,      // Pay-eligibility for current user's waitlisted spot
+            requiresWaiverAcceptance        // Waiver gate for the current user
         );
     }
 

--- a/apps/api/BHMHockey.Api/Services/IOrganizationService.cs
+++ b/apps/api/BHMHockey.Api/Services/IOrganizationService.cs
@@ -11,6 +11,13 @@ public interface IOrganizationService
     Task<bool> DeleteAsync(Guid id, Guid userId);
     Task<bool> SubscribeAsync(Guid organizationId, Guid userId);
     Task<bool> UnsubscribeAsync(Guid organizationId, Guid userId);
+
+    /// <summary>
+    /// Leave an organization: unsubscribe AND cancel upcoming Registered/Waitlisted
+    /// registrations in the org's events (reusing the standard cancellation path so
+    /// waitlist promotion side effects fire). Past events untouched. Idempotent.
+    /// </summary>
+    Task<bool> LeaveAsync(Guid organizationId, Guid userId);
     Task<List<OrganizationSubscriptionDto>> GetUserSubscriptionsAsync(Guid userId);
     Task<List<OrganizationDto>> GetUserAdminOrganizationsAsync(Guid userId);
     Task<List<OrganizationMemberDto>> GetMembersAsync(Guid organizationId, Guid requesterId);

--- a/apps/api/BHMHockey.Api/Services/IOrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/IOrganizationWaiverService.cs
@@ -1,0 +1,51 @@
+using BHMHockey.Api.Models.DTOs;
+
+namespace BHMHockey.Api.Services;
+
+public interface IOrganizationWaiverService
+{
+    /// <summary>
+    /// Get the org's current ACTIVE waiver (latest version row with non-empty text).
+    /// Returns null when the org has no waiver or the latest version was cleared.
+    /// </summary>
+    Task<OrganizationWaiverDto?> GetCurrentWaiverAsync(Guid organizationId);
+
+    /// <summary>
+    /// Create the next waiver version from the submitted text (admin only).
+    /// Text is trimmed; empty text deactivates the waiver (new empty version row,
+    /// history preserved). Saving text identical to the current version is a no-op
+    /// so members are not re-gated accidentally.
+    /// Returns the active waiver after the save, or null when no active waiver remains.
+    /// </summary>
+    Task<OrganizationWaiverDto?> SetWaiverAsync(Guid organizationId, string? text, Guid userId);
+
+    /// <summary>
+    /// Record that the user accepted a SPECIFIC waiver version. Rejects
+    /// (InvalidOperationException) when the id is not the org's current active
+    /// version (stale-version protection). Idempotent when already accepted.
+    /// </summary>
+    Task AcceptWaiverAsync(Guid organizationId, Guid waiverId, Guid userId);
+
+    /// <summary>
+    /// Orgs where the user holds an active (Registered/Waitlisted) registration on
+    /// an UPCOMING, non-cancelled event whose org has an active waiver the user
+    /// has not accepted. Powers the blocking accept-or-leave gate.
+    /// </summary>
+    Task<List<PendingWaiverDto>> GetPendingWaiversAsync(Guid userId);
+
+    /// <summary>
+    /// Id of the org's active waiver version, or null when none.
+    /// </summary>
+    Task<Guid?> GetActiveWaiverIdAsync(Guid organizationId);
+
+    /// <summary>
+    /// True when the org has an active waiver the user has not accepted.
+    /// </summary>
+    Task<bool> IsAcceptanceRequiredAsync(Guid organizationId, Guid userId);
+
+    /// <summary>
+    /// Render the org's current active waiver as a PDF.
+    /// Returns null when there is no active waiver.
+    /// </summary>
+    Task<(byte[] Content, string FileName)?> GetCurrentWaiverPdfAsync(Guid organizationId);
+}

--- a/apps/api/BHMHockey.Api/Services/OrganizationService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationService.cs
@@ -9,12 +9,20 @@ public class OrganizationService : IOrganizationService
 {
     private readonly AppDbContext _context;
     private readonly IOrganizationAdminService _adminService;
+    private readonly IOrganizationWaiverService _waiverService;
+    private readonly IEventService _eventService;
     private static readonly HashSet<string> ValidSkillLevels = new() { "Gold", "Silver", "Bronze", "D-League" };
 
-    public OrganizationService(AppDbContext context, IOrganizationAdminService adminService)
+    public OrganizationService(
+        AppDbContext context,
+        IOrganizationAdminService adminService,
+        IOrganizationWaiverService waiverService,
+        IEventService eventService)
     {
         _context = context;
         _adminService = adminService;
+        _waiverService = waiverService;
+        _eventService = eventService;
     }
 
     private void ValidateSkillLevels(List<string>? skillLevels)
@@ -263,6 +271,34 @@ public class OrganizationService : IOrganizationService
         return true;
     }
 
+    /// <summary>
+    /// Leave an organization: unsubscribe AND cancel the user's upcoming
+    /// Registered/Waitlisted registrations in that org's events. Cancellation
+    /// reuses the standard path (CancelRegistrationAsync) so its waitlist
+    /// promotion side effects fire. Past events are untouched. Idempotent.
+    /// </summary>
+    public async Task<bool> LeaveAsync(Guid organizationId, Guid userId)
+    {
+        var now = DateTime.UtcNow;
+
+        var upcomingEventIds = await _context.EventRegistrations
+            .Where(r => r.UserId == userId
+                && (r.Status == "Registered" || r.Status == "Waitlisted")
+                && r.Event.OrganizationId == organizationId
+                && r.Event.EventDate > now
+                && r.Event.Status != "Cancelled")
+            .Select(r => r.EventId)
+            .ToListAsync();
+
+        foreach (var eventId in upcomingEventIds)
+        {
+            await _eventService.CancelRegistrationAsync(eventId, userId);
+        }
+
+        await UnsubscribeAsync(organizationId, userId);
+        return true;
+    }
+
     public async Task<List<OrganizationSubscriptionDto>> GetUserSubscriptionsAsync(Guid userId)
     {
         var subscriptions = await _context.OrganizationSubscriptions
@@ -366,6 +402,18 @@ public class OrganizationService : IOrganizationService
             .GroupBy(ub => ub.UserId)
             .ToDictionary(g => g.Key, g => g.Count());
 
+        // Waiver status per member - only meaningful when an active waiver exists
+        // (flags stay null otherwise so clients hide the waiver UI entirely)
+        var activeWaiverId = await _waiverService.GetActiveWaiverIdAsync(organizationId);
+        HashSet<Guid>? acceptedUserIds = null;
+        if (activeWaiverId.HasValue)
+        {
+            acceptedUserIds = (await _context.WaiverAcceptances
+                .Where(a => a.WaiverId == activeWaiverId.Value && memberUserIds.Contains(a.UserId))
+                .Select(a => a.UserId)
+                .ToListAsync()).ToHashSet();
+        }
+
         // Build member DTOs
         var members = subscriptions.Select(s => new OrganizationMemberDto(
             s.User.Id,
@@ -376,7 +424,8 @@ public class OrganizationService : IOrganizationService
             s.SubscribedAt,
             adminUserIds.Contains(s.User.Id),
             badgesByUser.GetValueOrDefault(s.User.Id, new List<UserBadgeDto>()),
-            badgeCountsByUser.GetValueOrDefault(s.User.Id, 0)
+            badgeCountsByUser.GetValueOrDefault(s.User.Id, 0),
+            acceptedUserIds == null ? null : acceptedUserIds.Contains(s.User.Id)
         )).ToList();
 
         return members;

--- a/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
@@ -1,0 +1,264 @@
+using BHMHockey.Api.Data;
+using BHMHockey.Api.Models.DTOs;
+using BHMHockey.Api.Models.Entities;
+using Microsoft.EntityFrameworkCore;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+
+namespace BHMHockey.Api.Services;
+
+public class OrganizationWaiverService : IOrganizationWaiverService
+{
+    private readonly AppDbContext _context;
+    private readonly IOrganizationAdminService _adminService;
+    private readonly ILogger<OrganizationWaiverService> _logger;
+
+    public OrganizationWaiverService(
+        AppDbContext context,
+        IOrganizationAdminService adminService,
+        ILogger<OrganizationWaiverService> logger)
+    {
+        _context = context;
+        _adminService = adminService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Latest version row for the org, regardless of whether it is active.
+    /// </summary>
+    private async Task<OrganizationWaiver?> GetLatestWaiverAsync(Guid organizationId)
+    {
+        return await _context.OrganizationWaivers
+            .Where(w => w.OrganizationId == organizationId)
+            .OrderByDescending(w => w.Version)
+            .FirstOrDefaultAsync();
+    }
+
+    /// <summary>
+    /// Active waiver = latest version row IF its text is non-empty.
+    /// </summary>
+    private async Task<OrganizationWaiver?> GetActiveWaiverAsync(Guid organizationId)
+    {
+        var latest = await GetLatestWaiverAsync(organizationId);
+        return latest != null && latest.Text.Length > 0 ? latest : null;
+    }
+
+    private static OrganizationWaiverDto MapToDto(OrganizationWaiver waiver)
+    {
+        return new OrganizationWaiverDto(
+            waiver.Id,
+            waiver.OrganizationId,
+            waiver.Text,
+            waiver.Version,
+            waiver.CreatedAt
+        );
+    }
+
+    public async Task<OrganizationWaiverDto?> GetCurrentWaiverAsync(Guid organizationId)
+    {
+        var active = await GetActiveWaiverAsync(organizationId);
+        return active == null ? null : MapToDto(active);
+    }
+
+    public async Task<Guid?> GetActiveWaiverIdAsync(Guid organizationId)
+    {
+        var active = await GetActiveWaiverAsync(organizationId);
+        return active?.Id;
+    }
+
+    public async Task<bool> IsAcceptanceRequiredAsync(Guid organizationId, Guid userId)
+    {
+        var activeId = await GetActiveWaiverIdAsync(organizationId);
+        if (activeId == null)
+        {
+            return false;
+        }
+
+        var accepted = await _context.WaiverAcceptances
+            .AnyAsync(a => a.WaiverId == activeId.Value && a.UserId == userId);
+        return !accepted;
+    }
+
+    public async Task<OrganizationWaiverDto?> SetWaiverAsync(Guid organizationId, string? text, Guid userId)
+    {
+        var isAdmin = await _adminService.IsUserAdminAsync(organizationId, userId);
+        if (!isAdmin)
+        {
+            _logger.LogWarning("Set waiver denied for organization {OrganizationId}: user {UserId} is not an admin", organizationId, userId);
+            throw new UnauthorizedAccessException("Only organization admins can update the waiver");
+        }
+
+        var orgExists = await _context.Organizations.AnyAsync(o => o.Id == organizationId && o.IsActive);
+        if (!orgExists)
+        {
+            _logger.LogWarning("Set waiver failed: organization {OrganizationId} not found", organizationId);
+            throw new InvalidOperationException("Organization not found");
+        }
+
+        var trimmed = (text ?? string.Empty).Trim();
+        var latest = await GetLatestWaiverAsync(organizationId);
+
+        // No-op cases: clearing when nothing is active, or re-saving identical text
+        // (avoids pointless version rows and accidental re-gating of all members)
+        if (trimmed.Length == 0 && (latest == null || latest.Text.Length == 0))
+        {
+            return null;
+        }
+        if (latest != null && latest.Text == trimmed)
+        {
+            return MapToDto(latest);
+        }
+
+        // Immutable versioning: always a NEW row, never an update
+        var waiver = new OrganizationWaiver
+        {
+            OrganizationId = organizationId,
+            Text = trimmed,
+            Version = (latest?.Version ?? 0) + 1,
+            CreatedByUserId = userId
+        };
+
+        _context.OrganizationWaivers.Add(waiver);
+        await _context.SaveChangesAsync();
+
+        return trimmed.Length == 0 ? null : MapToDto(waiver);
+    }
+
+    public async Task AcceptWaiverAsync(Guid organizationId, Guid waiverId, Guid userId)
+    {
+        var active = await GetActiveWaiverAsync(organizationId);
+        if (active == null || active.Id != waiverId)
+        {
+            _logger.LogWarning(
+                "Waiver acceptance rejected for organization {OrganizationId}: waiver {WaiverId} is not the current active version",
+                organizationId, waiverId);
+            throw new InvalidOperationException("This waiver version is no longer current. Please review and accept the latest waiver.");
+        }
+
+        var alreadyAccepted = await _context.WaiverAcceptances
+            .AnyAsync(a => a.WaiverId == waiverId && a.UserId == userId);
+        if (alreadyAccepted)
+        {
+            return; // Idempotent
+        }
+
+        _context.WaiverAcceptances.Add(new WaiverAcceptance
+        {
+            UserId = userId,
+            WaiverId = waiverId
+        });
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task<List<PendingWaiverDto>> GetPendingWaiversAsync(Guid userId)
+    {
+        var now = DateTime.UtcNow;
+
+        // Orgs where the user holds an active registration on an upcoming, non-cancelled event
+        var orgIds = await _context.EventRegistrations
+            .Where(r => r.UserId == userId
+                && (r.Status == "Registered" || r.Status == "Waitlisted")
+                && r.Event.OrganizationId != null
+                && r.Event.EventDate > now
+                && r.Event.Status != "Cancelled")
+            .Select(r => r.Event.OrganizationId!.Value)
+            .Distinct()
+            .ToListAsync();
+
+        if (orgIds.Count == 0)
+        {
+            return new List<PendingWaiverDto>();
+        }
+
+        var orgs = await _context.Organizations
+            .Where(o => orgIds.Contains(o.Id) && o.IsActive)
+            .OrderBy(o => o.Name)
+            .ToListAsync();
+
+        var pending = new List<PendingWaiverDto>();
+        foreach (var org in orgs)
+        {
+            var active = await GetActiveWaiverAsync(org.Id);
+            if (active == null)
+            {
+                continue;
+            }
+
+            var accepted = await _context.WaiverAcceptances
+                .AnyAsync(a => a.WaiverId == active.Id && a.UserId == userId);
+            if (!accepted)
+            {
+                pending.Add(new PendingWaiverDto(org.Id, org.Name, MapToDto(active)));
+            }
+        }
+
+        return pending;
+    }
+
+    public async Task<(byte[] Content, string FileName)?> GetCurrentWaiverPdfAsync(Guid organizationId)
+    {
+        var active = await GetActiveWaiverAsync(organizationId);
+        if (active == null)
+        {
+            return null;
+        }
+
+        var org = await _context.Organizations.FindAsync(organizationId);
+        if (org == null || !org.IsActive)
+        {
+            return null;
+        }
+
+        var content = GenerateWaiverPdf(org.Name, active);
+        var fileName = $"{SanitizeFileName(org.Name)}-waiver-v{active.Version}.pdf";
+        return (content, fileName);
+    }
+
+    private static byte[] GenerateWaiverPdf(string organizationName, OrganizationWaiver waiver)
+    {
+        var document = Document.Create(container =>
+        {
+            container.Page(page =>
+            {
+                page.Size(PageSizes.Letter);
+                page.Margin(54);
+                page.DefaultTextStyle(style => style.FontSize(11));
+
+                page.Header().Column(column =>
+                {
+                    column.Item().Text(organizationName).FontSize(20).SemiBold();
+                    column.Item().Text($"Legal Waiver - Version {waiver.Version} - Effective {waiver.CreatedAt:MMMM d, yyyy}")
+                        .FontSize(10)
+                        .FontColor(Colors.Grey.Darken1);
+                    column.Item().PaddingTop(8).LineHorizontal(1).LineColor(Colors.Grey.Lighten2);
+                });
+
+                // Body text wraps and paginates automatically
+                page.Content().PaddingVertical(14).Text(waiver.Text).LineHeight(1.4f);
+
+                page.Footer().AlignCenter().Text(text =>
+                {
+                    text.DefaultTextStyle(style => style.FontSize(9).FontColor(Colors.Grey.Darken1));
+                    text.CurrentPageNumber();
+                    text.Span(" of ");
+                    text.TotalPages();
+                });
+            });
+        });
+
+        return document.GeneratePdf();
+    }
+
+    private static string SanitizeFileName(string name)
+    {
+        var safe = new string(name
+            .Select(c => char.IsLetterOrDigit(c) ? c : '-')
+            .ToArray())
+            .Trim('-');
+        while (safe.Contains("--"))
+        {
+            safe = safe.Replace("--", "-");
+        }
+        return string.IsNullOrEmpty(safe) ? "organization" : safe.ToLowerInvariant();
+    }
+}

--- a/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
@@ -233,8 +233,22 @@ public class OrganizationWaiverService : IOrganizationWaiverService
                     column.Item().PaddingTop(8).LineHorizontal(1).LineColor(Colors.Grey.Lighten2);
                 });
 
-                // Body text wraps and paginates automatically
-                page.Content().PaddingVertical(14).Text(waiver.Text).LineHeight(1.4f);
+                // Body text wraps and paginates automatically; **markers** render bold
+                page.Content().PaddingVertical(14).Text(text =>
+                {
+                    text.DefaultTextStyle(style => style.LineHeight(1.4f));
+                    foreach (var (segment, bold) in ParseBoldSegments(waiver.Text))
+                    {
+                        if (bold)
+                        {
+                            text.Span(segment).SemiBold();
+                        }
+                        else
+                        {
+                            text.Span(segment);
+                        }
+                    }
+                });
 
                 page.Footer().AlignCenter().Text(text =>
                 {
@@ -247,6 +261,37 @@ public class OrganizationWaiverService : IOrganizationWaiverService
         });
 
         return document.GeneratePdf();
+    }
+
+    /// <summary>
+    /// Splits waiver text on ** bold markers. Mirrors the mobile parser
+    /// (apps/mobile/utils/waiverFormat.ts) — keep the two in sync. An
+    /// unmatched trailing ** is emitted literally rather than bolding the
+    /// remainder of the document.
+    /// </summary>
+    public static IReadOnlyList<(string Text, bool Bold)> ParseBoldSegments(string text)
+    {
+        var parts = text.Split("**");
+        if (parts.Length == 1)
+        {
+            return new[] { (text, false) };
+        }
+
+        var unbalanced = parts.Length % 2 == 0;
+        var segments = new List<(string, bool)>();
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var isLast = i == parts.Length - 1;
+            if (unbalanced && isLast)
+            {
+                segments.Add(($"**{parts[i]}", false));
+            }
+            else if (parts[i].Length > 0)
+            {
+                segments.Add((parts[i], i % 2 == 1));
+            }
+        }
+        return segments;
     }
 
     private static string SanitizeFileName(string name)

--- a/apps/mobile/__tests__/stores/eventStore.test.ts
+++ b/apps/mobile/__tests__/stores/eventStore.test.ts
@@ -70,6 +70,8 @@ const createMockEvent = (overrides: Partial<EventDto> = {}): EventDto => ({
   isRosterPublished: true,
   // Waitlist visibility (pre-publish)
   showWaitlistBeforePublish: false,
+  // Waiver gate
+  requiresWaiverAcceptance: false,
   ...overrides,
 });
 

--- a/apps/mobile/__tests__/stores/organizationStore.test.ts
+++ b/apps/mobile/__tests__/stores/organizationStore.test.ts
@@ -12,6 +12,8 @@ const mockGetAutoRoster = jest.fn();
 const mockAddAutoRosterMember = jest.fn();
 const mockRemoveAutoRosterMember = jest.fn();
 const mockReorderAutoRoster = jest.fn();
+const mockGetWaiver = jest.fn();
+const mockSetWaiver = jest.fn();
 
 // Mock the api-client module
 jest.mock('@bhmhockey/api-client', () => ({
@@ -24,12 +26,14 @@ jest.mock('@bhmhockey/api-client', () => ({
     addAutoRosterMember: mockAddAutoRosterMember,
     removeAutoRosterMember: mockRemoveAutoRosterMember,
     reorderAutoRoster: mockReorderAutoRoster,
+    getWaiver: mockGetWaiver,
+    setWaiver: mockSetWaiver,
   },
 }));
 
 // Import after mocking
 import { useOrganizationStore } from '../../stores/organizationStore';
-import type { Organization, OrganizationSubscription, AutoRosterMember } from '@bhmhockey/shared';
+import type { Organization, OrganizationSubscription, AutoRosterMember, OrganizationWaiver } from '@bhmhockey/shared';
 
 const createMockOrg = (overrides: Partial<Organization> = {}): Organization => ({
   id: 'org-1',
@@ -64,6 +68,15 @@ const createMockAutoRosterMember = (overrides: Partial<AutoRosterMember> = {}): 
   ...overrides,
 });
 
+const createMockWaiver = (overrides: Partial<OrganizationWaiver> = {}): OrganizationWaiver => ({
+  id: 'waiver-1',
+  organizationId: 'org-1',
+  text: 'You play at your own risk.',
+  version: 1,
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
 describe('organizationStore', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -74,6 +87,8 @@ describe('organizationStore', () => {
       autoRoster: [],
       autoRosterOrgId: null,
       members: [],
+      waiver: null,
+      waiverOrgId: null,
       isLoading: false,
       error: null,
     });
@@ -362,6 +377,72 @@ describe('organizationStore', () => {
       expect(result).toBe(false);
       expect(useOrganizationStore.getState().autoRoster.map((m) => m.userId)).toEqual(['user-1', 'user-2']);
       expect(useOrganizationStore.getState().error).toBe('Reorder failed');
+    });
+  });
+
+  describe('fetchWaiver', () => {
+    it('sets the waiver and org id on success', async () => {
+      const waiver = createMockWaiver();
+      mockGetWaiver.mockResolvedValue(waiver);
+
+      const result = await useOrganizationStore.getState().fetchWaiver('org-1');
+
+      expect(result).toEqual(waiver);
+      expect(mockGetWaiver).toHaveBeenCalledWith('org-1');
+      expect(useOrganizationStore.getState().waiver).toEqual(waiver);
+      expect(useOrganizationStore.getState().waiverOrgId).toBe('org-1');
+    });
+
+    it('treats a 404 as "no active waiver", not an error', async () => {
+      mockGetWaiver.mockRejectedValue({ message: 'Not found', statusCode: 404 });
+
+      const result = await useOrganizationStore.getState().fetchWaiver('org-1');
+
+      expect(result).toBeNull();
+      expect(useOrganizationStore.getState().waiver).toBeNull();
+      expect(useOrganizationStore.getState().waiverOrgId).toBe('org-1');
+      expect(useOrganizationStore.getState().error).toBeNull();
+    });
+
+    it('sets error on non-404 failure', async () => {
+      mockGetWaiver.mockRejectedValue({ message: 'Server error', statusCode: 500 });
+
+      const result = await useOrganizationStore.getState().fetchWaiver('org-1');
+
+      expect(result).toBeNull();
+      expect(useOrganizationStore.getState().error).toBe('Server error');
+    });
+  });
+
+  describe('saveWaiver', () => {
+    it('stores the new active waiver on success', async () => {
+      const waiver = createMockWaiver({ version: 2 });
+      mockSetWaiver.mockResolvedValue(waiver);
+
+      const result = await useOrganizationStore.getState().saveWaiver('org-1', 'New text');
+
+      expect(result).toBe(true);
+      expect(mockSetWaiver).toHaveBeenCalledWith('org-1', 'New text');
+      expect(useOrganizationStore.getState().waiver).toEqual(waiver);
+    });
+
+    it('stores null when the waiver was cleared', async () => {
+      useOrganizationStore.setState({ waiver: createMockWaiver(), waiverOrgId: 'org-1' });
+      mockSetWaiver.mockResolvedValue(null);
+
+      const result = await useOrganizationStore.getState().saveWaiver('org-1', '');
+
+      expect(result).toBe(true);
+      expect(useOrganizationStore.getState().waiver).toBeNull();
+    });
+
+    it('sets error and returns false on failure', async () => {
+      mockSetWaiver.mockRejectedValue(new Error('Only organization admins can update the waiver'));
+
+      const result = await useOrganizationStore.getState().saveWaiver('org-1', 'New text');
+
+      expect(result).toBe(false);
+      expect(useOrganizationStore.getState().error).toBe('Only organization admins can update the waiver');
     });
   });
 

--- a/apps/mobile/__tests__/stores/waiverStore.test.ts
+++ b/apps/mobile/__tests__/stores/waiverStore.test.ts
@@ -1,0 +1,167 @@
+/**
+ * WaiverStore Tests - Protecting the blocking accept-or-leave gate queue.
+ * These tests ensure the pending queue advances on accept/leave and that
+ * failures surface errors without corrupting the queue.
+ */
+
+// Mock functions must be defined before jest.mock
+const mockGetPendingWaivers = jest.fn();
+const mockAcceptWaiver = jest.fn();
+const mockLeaveOrganization = jest.fn();
+
+// Mock the api-client module
+jest.mock('@bhmhockey/api-client', () => ({
+  organizationService: {
+    getPendingWaivers: mockGetPendingWaivers,
+    acceptWaiver: mockAcceptWaiver,
+    leaveOrganization: mockLeaveOrganization,
+  },
+}));
+
+// Import after mocking
+import { useWaiverStore } from '../../stores/waiverStore';
+import type { PendingWaiver } from '@bhmhockey/shared';
+
+const createMockPendingWaiver = (overrides: Partial<PendingWaiver> = {}): PendingWaiver => ({
+  organizationId: 'org-1',
+  organizationName: 'Test Org',
+  waiver: {
+    id: 'waiver-1',
+    organizationId: 'org-1',
+    text: 'You play at your own risk.',
+    version: 1,
+    createdAt: new Date().toISOString(),
+  },
+  ...overrides,
+});
+
+describe('waiverStore', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useWaiverStore.setState({
+      pendingWaivers: [],
+      isFetching: false,
+      error: null,
+    });
+  });
+
+  describe('fetchPendingWaivers', () => {
+    it('sets the pending queue on successful fetch', async () => {
+      const pending = [createMockPendingWaiver()];
+      mockGetPendingWaivers.mockResolvedValue(pending);
+
+      await useWaiverStore.getState().fetchPendingWaivers();
+
+      expect(useWaiverStore.getState().pendingWaivers).toEqual(pending);
+      expect(useWaiverStore.getState().isFetching).toBe(false);
+      expect(useWaiverStore.getState().error).toBeNull();
+    });
+
+    it('keeps the current queue and sets error on failure', async () => {
+      const existing = [createMockPendingWaiver()];
+      useWaiverStore.setState({ pendingWaivers: existing });
+      mockGetPendingWaivers.mockRejectedValue(new Error('Network error'));
+
+      await useWaiverStore.getState().fetchPendingWaivers();
+
+      expect(useWaiverStore.getState().pendingWaivers).toEqual(existing);
+      expect(useWaiverStore.getState().error).toBe('Network error');
+      expect(useWaiverStore.getState().isFetching).toBe(false);
+    });
+
+    it('skips duplicate concurrent fetches', async () => {
+      let resolveFetch: (value: PendingWaiver[]) => void;
+      mockGetPendingWaivers.mockReturnValue(
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+      );
+
+      const first = useWaiverStore.getState().fetchPendingWaivers();
+      const second = useWaiverStore.getState().fetchPendingWaivers();
+
+      resolveFetch!([]);
+      await Promise.all([first, second]);
+
+      expect(mockGetPendingWaivers).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('acceptWaiver', () => {
+    it('removes the org from the queue on success', async () => {
+      const org1 = createMockPendingWaiver();
+      const org2 = createMockPendingWaiver({
+        organizationId: 'org-2',
+        organizationName: 'Second Org',
+        waiver: { id: 'waiver-2', organizationId: 'org-2', text: 'text', version: 1, createdAt: new Date().toISOString() },
+      });
+      useWaiverStore.setState({ pendingWaivers: [org1, org2] });
+      mockAcceptWaiver.mockResolvedValue(undefined);
+
+      const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1');
+
+      expect(result).toBe(true);
+      expect(mockAcceptWaiver).toHaveBeenCalledWith('org-1', 'waiver-1');
+      // Queue advances to the next org
+      expect(useWaiverStore.getState().pendingWaivers).toEqual([org2]);
+    });
+
+    it('sets error, refreshes the queue, and returns false on failure', async () => {
+      const stale = createMockPendingWaiver();
+      useWaiverStore.setState({ pendingWaivers: [stale] });
+      mockAcceptWaiver.mockRejectedValue(new Error('This waiver version is no longer current.'));
+      const refreshed = [createMockPendingWaiver({
+        waiver: { ...stale.waiver, id: 'waiver-v2', version: 2 },
+      })];
+      mockGetPendingWaivers.mockResolvedValue(refreshed);
+
+      const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1');
+
+      expect(result).toBe(false);
+      expect(useWaiverStore.getState().error).toBe('This waiver version is no longer current.');
+      // Stale-version protection: queue re-fetched so the latest text shows
+      expect(mockGetPendingWaivers).toHaveBeenCalled();
+      expect(useWaiverStore.getState().pendingWaivers).toEqual(refreshed);
+    });
+  });
+
+  describe('leaveOrganization', () => {
+    it('removes the org from the queue on success', async () => {
+      const pending = createMockPendingWaiver();
+      useWaiverStore.setState({ pendingWaivers: [pending] });
+      mockLeaveOrganization.mockResolvedValue(undefined);
+
+      const result = await useWaiverStore.getState().leaveOrganization('org-1');
+
+      expect(result).toBe(true);
+      expect(mockLeaveOrganization).toHaveBeenCalledWith('org-1');
+      expect(useWaiverStore.getState().pendingWaivers).toEqual([]);
+    });
+
+    it('keeps the queue and sets error on failure', async () => {
+      const pending = createMockPendingWaiver();
+      useWaiverStore.setState({ pendingWaivers: [pending] });
+      mockLeaveOrganization.mockRejectedValue(new Error('Leave failed'));
+
+      const result = await useWaiverStore.getState().leaveOrganization('org-1');
+
+      expect(result).toBe(false);
+      expect(useWaiverStore.getState().pendingWaivers).toEqual([pending]);
+      expect(useWaiverStore.getState().error).toBe('Leave failed');
+    });
+  });
+
+  describe('reset', () => {
+    it('clears the queue and error state', () => {
+      useWaiverStore.setState({
+        pendingWaivers: [createMockPendingWaiver()],
+        error: 'Some error',
+      });
+
+      useWaiverStore.getState().reset();
+
+      expect(useWaiverStore.getState().pendingWaivers).toEqual([]);
+      expect(useWaiverStore.getState().error).toBeNull();
+    });
+  });
+});

--- a/apps/mobile/__tests__/utils/waiverFormat.test.ts
+++ b/apps/mobile/__tests__/utils/waiverFormat.test.ts
@@ -1,0 +1,43 @@
+import { parseWaiverSegments } from '../../utils/waiverFormat';
+
+describe('parseWaiverSegments', () => {
+  it('returns plain text untouched when there are no markers', () => {
+    expect(parseWaiverSegments('Just a waiver.')).toEqual([
+      { text: 'Just a waiver.', bold: false },
+    ]);
+  });
+
+  it('bolds a single marked section', () => {
+    expect(parseWaiverSegments('Read **carefully** please')).toEqual([
+      { text: 'Read ', bold: false },
+      { text: 'carefully', bold: true },
+      { text: ' please', bold: false },
+    ]);
+  });
+
+  it('handles multiple bold sections', () => {
+    expect(parseWaiverSegments('**A** and **B**')).toEqual([
+      { text: 'A', bold: true },
+      { text: ' and ', bold: false },
+      { text: 'B', bold: true },
+    ]);
+  });
+
+  it('renders an unmatched trailing marker literally instead of bolding the rest', () => {
+    expect(parseWaiverSegments('Signed **here and more text')).toEqual([
+      { text: 'Signed ', bold: false },
+      { text: '**here and more text', bold: false },
+    ]);
+  });
+
+  it('handles bold spanning newlines', () => {
+    expect(parseWaiverSegments('**Section 1**\nBody')).toEqual([
+      { text: 'Section 1', bold: true },
+      { text: '\nBody', bold: false },
+    ]);
+  });
+
+  it('handles empty input', () => {
+    expect(parseWaiverSegments('')).toEqual([{ text: '', bold: false }]);
+  });
+});

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,6 +1,6 @@
 import { Stack } from 'expo-router';
 import { useEffect, useRef } from 'react';
-import { Text, TextInput, View, AppState } from 'react-native';
+import { Text, TextInput, View, AppState, Alert } from 'react-native';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import * as Notifications from 'expo-notifications';
@@ -9,7 +9,8 @@ import { getApiUrl } from '../config/api';
 import { colors } from '../theme';
 import { useAuthStore } from '../stores/authStore';
 import { useCelebrationStore } from '../stores/celebrationStore';
-import { BadgeCelebrationModal, EnvBanner } from '../components';
+import { useWaiverStore } from '../stores/waiverStore';
+import { BadgeCelebrationModal, EnvBanner, WaiverAcceptanceModal } from '../components';
 import { useBadgeCelebration } from '../hooks';
 import {
   registerForPushNotificationsAsync,
@@ -46,6 +47,8 @@ function RootLayoutContent() {
   const { fetchUncelebrated } = useCelebrationStore();
   const isShowingCelebration = useCelebrationStore((state) => state.isShowingCelebration);
   const { currentBadge, remaining, dismiss, navigateToTrophyCase } = useBadgeCelebration();
+  const pendingWaivers = useWaiverStore((state) => state.pendingWaivers);
+  const fetchPendingWaivers = useWaiverStore((state) => state.fetchPendingWaivers);
 
   useOtaUpdates();
   const notificationListener = useRef<Notifications.Subscription | null>(null);
@@ -167,6 +170,71 @@ function RootLayoutContent() {
     };
   }, [isAuthenticated]);
 
+  // Blocking waiver gate: on app open, foreground, and after login, check for
+  // orgs where the user holds an upcoming registration but hasn't accepted the
+  // current waiver. Non-empty queue renders a non-dismissible modal below.
+  useEffect(() => {
+    if (!isAuthenticated) {
+      useWaiverStore.getState().reset();
+      return;
+    }
+
+    // Fetch on mount / after login
+    fetchPendingWaivers();
+
+    // Re-check whenever the app comes to the foreground
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (nextAppState === 'active') {
+        fetchPendingWaivers();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isAuthenticated, fetchPendingWaivers]);
+
+  // Accept-or-leave handlers for the blocking gate (one org at a time, queued)
+  const currentPendingWaiver = pendingWaivers.length > 0 ? pendingWaivers[0] : null;
+
+  const handleGateAgree = async () => {
+    if (!currentPendingWaiver) return;
+    const ok = await useWaiverStore
+      .getState()
+      .acceptWaiver(currentPendingWaiver.organizationId, currentPendingWaiver.waiver.id);
+    if (!ok) {
+      Alert.alert(
+        'Error',
+        useWaiverStore.getState().error || 'Failed to accept waiver. Please try again.'
+      );
+    }
+  };
+
+  const handleGateLeave = () => {
+    if (!currentPendingWaiver) return;
+    const { organizationId, organizationName } = currentPendingWaiver;
+    Alert.alert(
+      'Leave Organization',
+      `If you leave ${organizationName} you will lose your registration for any upcoming events. This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Leave',
+          style: 'destructive',
+          onPress: async () => {
+            const ok = await useWaiverStore.getState().leaveOrganization(organizationId);
+            if (!ok) {
+              Alert.alert(
+                'Error',
+                useWaiverStore.getState().error || 'Failed to leave organization. Please try again.'
+              );
+            }
+          },
+        },
+      ]
+    );
+  };
+
   // AppState listener for badge celebration queue
   // Checks for uncelebrated badges when app comes to foreground
   useEffect(() => {
@@ -193,6 +261,18 @@ function RootLayoutContent() {
   return (
     <View style={{ flex: 1, paddingTop: insets.top, backgroundColor: colors.bg.darkest }}>
       <EnvBanner />
+
+      {/* Blocking waiver gate - non-dismissible, one org at a time until the
+          queue is empty. Accept or leave are the only ways forward. */}
+      {isAuthenticated && currentPendingWaiver && (
+        <WaiverAcceptanceModal
+          visible
+          organizationName={currentPendingWaiver.organizationName}
+          waiver={currentPendingWaiver.waiver}
+          onAgree={handleGateAgree}
+          onLeaveOrganization={handleGateLeave}
+        />
+      )}
 
       {/* Badge celebration modal - shown when uncelebrated badges exist */}
       {isShowingCelebration && currentBadge && (

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -13,6 +13,8 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useLocalSearchParams, useRouter, useFocusEffect, Stack } from 'expo-router';
 import { useEventStore } from '../../../stores/eventStore';
 import { useAuthStore } from '../../../stores/authStore';
+import { useOrganizationStore } from '../../../stores/organizationStore';
+import { useWaiverStore } from '../../../stores/waiverStore';
 import { openVenmoPayment } from '../../../utils/venmo';
 import {
   SegmentedControl,
@@ -20,6 +22,7 @@ import {
   EventRosterTab,
   EventChatTab,
   RegistrationFooter,
+  WaiverAcceptanceModal,
 } from '../../../components';
 import type { TabKey } from '../../../components';
 import { colors, spacing } from '../../../theme';
@@ -32,6 +35,9 @@ export default function EventDetailScreen() {
   const [selectedTab, setSelectedTab] = useState<TabKey>('info');
   const [isProcessing, setIsProcessing] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [waiverModalVisible, setWaiverModalVisible] = useState(false);
+  const orgWaiver = useOrganizationStore((state) => state.waiver);
+  const fetchWaiver = useOrganizationStore((state) => state.fetchWaiver);
 
   const {
     selectedEvent,
@@ -92,25 +98,15 @@ export default function EventDetailScreen() {
     }
   };
 
-  const handleRegister = async () => {
-    if (!id || !isAuthenticated || !user) return;
+  // The existing registration flow (position picker etc.). Runs after the
+  // waiver gate (when required) has been satisfied.
+  const proceedWithRegistration = async () => {
+    if (!id || !user) return;
 
     const positions = user.positions;
     const positionCount = positions
       ? Object.keys(positions).filter((k) => positions[k as keyof typeof positions]).length
       : 0;
-
-    if (positionCount === 0) {
-      Alert.alert(
-        'Set Up Profile',
-        'Please set up your positions in your profile before registering for events.',
-        [
-          { text: 'Cancel', style: 'cancel' },
-          { text: 'Go to Profile', onPress: () => router.push('/(tabs)/profile') },
-        ]
-      );
-      return;
-    }
 
     const showResultMessage = (
       result: RegistrationResultDto | null,
@@ -190,6 +186,64 @@ export default function EventDetailScreen() {
         },
       ]);
     }
+  };
+
+  const handleRegister = async () => {
+    if (!id || !isAuthenticated || !user) return;
+
+    const positions = user.positions;
+    const positionCount = positions
+      ? Object.keys(positions).filter((k) => positions[k as keyof typeof positions]).length
+      : 0;
+
+    if (positionCount === 0) {
+      Alert.alert(
+        'Set Up Profile',
+        'Please set up your positions in your profile before registering for events.',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Go to Profile', onPress: () => router.push('/(tabs)/profile') },
+        ]
+      );
+      return;
+    }
+
+    // Waiver gate: org events with an active waiver the user hasn't accepted
+    // show the acceptance modal BEFORE registering
+    if (selectedEvent?.requiresWaiverAcceptance && selectedEvent.organizationId) {
+      const waiver = await fetchWaiver(selectedEvent.organizationId);
+      if (waiver) {
+        setWaiverModalVisible(true);
+        return;
+      }
+      // Waiver deactivated since the event was fetched - fall through
+    }
+
+    await proceedWithRegistration();
+  };
+
+  // Agree in the registration-flow waiver modal: accept, then continue straight
+  // into the registration flow (position picker etc.) in the same gesture
+  const handleWaiverAgree = async () => {
+    if (!selectedEvent?.organizationId || !orgWaiver) return;
+
+    const ok = await useWaiverStore
+      .getState()
+      .acceptWaiver(selectedEvent.organizationId, orgWaiver.id);
+
+    if (!ok) {
+      setWaiverModalVisible(false);
+      Alert.alert(
+        'Error',
+        useWaiverStore.getState().error || 'Failed to accept waiver. Please try again.'
+      );
+      // Refresh so a stale waiver version is replaced by the latest state
+      if (id) fetchEventById(id);
+      return;
+    }
+
+    setWaiverModalVisible(false);
+    await proceedWithRegistration();
   };
 
   const handleCancelRegistration = async () => {
@@ -379,6 +433,17 @@ export default function EventDetailScreen() {
             isProcessing={isProcessing}
             onRegister={handleRegister}
           />
+
+          {/* Waiver acceptance modal (registration flow) - decline returns to the event */}
+          {orgWaiver && (
+            <WaiverAcceptanceModal
+              visible={waiverModalVisible}
+              organizationName={selectedEvent.organizationName || 'Organization'}
+              waiver={orgWaiver}
+              onAgree={handleWaiverAgree}
+              onClose={() => setWaiverModalVisible(false)}
+            />
+          )}
         </View>
       )}
     </GestureHandlerRootView>

--- a/apps/mobile/app/organizations/[id].tsx
+++ b/apps/mobile/app/organizations/[id].tsx
@@ -221,6 +221,13 @@ export default function OrganizationDetailScreen() {
 
   const isAdmin = organization?.isAdmin;
 
+  // Waiver status - flags are only non-null when the org has an active waiver
+  const waiverActive = members.some(
+    (m) => m.hasAcceptedCurrentWaiver !== null && m.hasAcceptedCurrentWaiver !== undefined
+  );
+  const waiverAcceptedCount = members.filter((m) => m.hasAcceptedCurrentWaiver === true).length;
+  const waiverNotAcceptedCount = members.filter((m) => m.hasAcceptedCurrentWaiver === false).length;
+
   return (
     <>
       <Stack.Screen
@@ -290,6 +297,12 @@ export default function OrganizationDetailScreen() {
               <Text style={styles.membersToggle}>{showMembers ? '▲' : '▼'}</Text>
             </TouchableOpacity>
 
+            {showMembers && waiverActive && (
+              <Text style={styles.waiverSummary} allowFontScaling={false}>
+                Waiver: {waiverAcceptedCount} accepted · {waiverNotAcceptedCount} not yet accepted
+              </Text>
+            )}
+
             {showMembers && (
               <View style={styles.membersList}>
                 {isLoadingMembers ? (
@@ -317,6 +330,12 @@ export default function OrganizationDetailScreen() {
                               {member.firstName} {member.lastName}
                             </Text>
                             {member.isAdmin && <Badge variant="purple">Admin</Badge>}
+                            {member.hasAcceptedCurrentWaiver === true && (
+                              <Badge variant="green">Waiver ✓</Badge>
+                            )}
+                            {member.hasAcceptedCurrentWaiver === false && (
+                              <Badge variant="warning">No waiver</Badge>
+                            )}
                             {isCurrentUser && <Text style={styles.youLabel}>(You)</Text>}
                           </View>
                           {/* Show email for admins, badges for everyone */}
@@ -377,6 +396,17 @@ export default function OrganizationDetailScreen() {
           >
             <Ionicons name="settings-outline" size={20} color={colors.text.secondary} />
             <Text style={styles.settingsButtonText}>Event Defaults</Text>
+          </TouchableOpacity>
+        )}
+
+        {/* Legal Waiver Button - visible to admins only */}
+        {isAdmin && (
+          <TouchableOpacity
+            style={styles.settingsButton}
+            onPress={() => router.push(`/organizations/${id}/waiver`)}
+          >
+            <Ionicons name="document-text-outline" size={20} color={colors.text.secondary} />
+            <Text style={styles.settingsButtonText}>Legal Waiver</Text>
           </TouchableOpacity>
         )}
 
@@ -537,6 +567,12 @@ const styles = StyleSheet.create({
   membersList: {
     paddingHorizontal: spacing.md,
     paddingBottom: spacing.md,
+  },
+  waiverSummary: {
+    fontSize: 13,
+    color: colors.text.muted,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.sm,
   },
   noMembers: {
     color: colors.text.muted,

--- a/apps/mobile/app/organizations/[id]/waiver.tsx
+++ b/apps/mobile/app/organizations/[id]/waiver.tsx
@@ -1,0 +1,240 @@
+import { useState, useEffect } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { useLocalSearchParams, useRouter, Stack } from 'expo-router';
+import { organizationService } from '@bhmhockey/api-client';
+import { useOrganizationStore } from '../../../stores/organizationStore';
+import { colors, spacing, radius } from '../../../theme';
+
+export default function OrganizationWaiverScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+
+  const fetchWaiver = useOrganizationStore((state) => state.fetchWaiver);
+  const saveWaiver = useOrganizationStore((state) => state.saveWaiver);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [text, setText] = useState('');
+  const [currentVersion, setCurrentVersion] = useState<number | null>(null);
+
+  useEffect(() => {
+    load();
+  }, [id]);
+
+  const load = async () => {
+    if (!id) return;
+
+    setIsLoading(true);
+    try {
+      // Admin gate - same pattern as the Event Defaults screen
+      const org = await organizationService.getById(id);
+      if (!org.isAdmin) {
+        Alert.alert('Access Denied', 'Only organization admins can edit the waiver');
+        router.back();
+        return;
+      }
+
+      const waiver = await fetchWaiver(id);
+      setText(waiver?.text ?? '');
+      setCurrentVersion(waiver?.version ?? null);
+    } catch (error) {
+      Alert.alert('Error', 'Failed to load organization');
+      router.back();
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleSave = () => {
+    if (!id) return;
+
+    const trimmed = text.trim();
+    const isClearing = trimmed.length === 0;
+
+    const title = isClearing ? 'Disable Waiver' : 'Save New Version';
+    const message = isClearing
+      ? 'Saving with no text disables the waiver. Members will no longer need to accept terms to register or play. Past versions and acceptance history are preserved.'
+      : 'This creates a new version. All members must accept the new terms before registering or continuing in upcoming games.';
+
+    Alert.alert(title, message, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: isClearing ? 'Disable' : 'Save',
+        style: isClearing ? 'destructive' : 'default',
+        onPress: async () => {
+          setIsSaving(true);
+          try {
+            const ok = await saveWaiver(id, trimmed);
+            if (ok) {
+              Alert.alert(
+                'Saved',
+                isClearing ? 'The waiver has been disabled.' : 'The new waiver version is now in effect.',
+                [{ text: 'OK', onPress: () => router.back() }]
+              );
+            } else {
+              Alert.alert(
+                'Error',
+                useOrganizationStore.getState().error || 'Failed to save waiver'
+              );
+            }
+          } finally {
+            setIsSaving(false);
+          }
+        },
+      },
+    ]);
+  };
+
+  return (
+    <>
+      <Stack.Screen
+        options={{
+          title: 'Legal Waiver',
+          headerBackTitle: 'Back',
+          headerStyle: { backgroundColor: colors.bg.dark },
+          headerTintColor: colors.text.primary,
+        }}
+      />
+
+      {isLoading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={colors.primary.teal} />
+        </View>
+      ) : (
+        <KeyboardAvoidingView
+          style={{ flex: 1, backgroundColor: colors.bg.darkest }}
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+        >
+          <ScrollView style={styles.container} keyboardShouldPersistTaps="handled">
+            {/* Explanation */}
+            <View style={styles.explanationBox}>
+              <Text style={styles.explanationText} allowFontScaling={false}>
+                Members must accept the current waiver before registering for this
+                organization's games. Saving creates a new version that everyone must
+                accept again. Clearing the text disables the waiver.
+              </Text>
+            </View>
+
+            {currentVersion !== null && (
+              <Text style={styles.versionText} allowFontScaling={false}>
+                Current version: {currentVersion}
+              </Text>
+            )}
+
+            {/* Waiver text editor */}
+            <View style={styles.field}>
+              <Text style={styles.label} allowFontScaling={false}>Waiver Text</Text>
+              <TextInput
+                style={styles.textArea}
+                value={text}
+                onChangeText={setText}
+                placeholder="Enter the full waiver text members must accept…"
+                placeholderTextColor={colors.text.muted}
+                multiline
+                textAlignVertical="top"
+                allowFontScaling={false}
+              />
+            </View>
+
+            {/* Save Button */}
+            <TouchableOpacity
+              style={[styles.saveButton, isSaving && styles.saveButtonDisabled]}
+              onPress={handleSave}
+              disabled={isSaving}
+            >
+              {isSaving ? (
+                <ActivityIndicator color={colors.bg.darkest} />
+              ) : (
+                <Text style={styles.saveButtonText} allowFontScaling={false}>Save Waiver</Text>
+              )}
+            </TouchableOpacity>
+
+            {/* Bottom padding */}
+            <View style={{ height: 40 }} />
+          </ScrollView>
+        </KeyboardAvoidingView>
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg.darkest,
+    padding: spacing.md,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.bg.darkest,
+  },
+  explanationBox: {
+    backgroundColor: colors.bg.dark,
+    padding: spacing.md,
+    borderRadius: radius.md,
+    marginBottom: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+  },
+  explanationText: {
+    fontSize: 14,
+    color: colors.text.secondary,
+    lineHeight: 20,
+  },
+  versionText: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginBottom: spacing.md,
+  },
+  field: {
+    marginBottom: spacing.lg,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.text.muted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: spacing.xs,
+  },
+  textArea: {
+    backgroundColor: colors.bg.elevated,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    fontSize: 15,
+    lineHeight: 22,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    color: colors.text.primary,
+    minHeight: 280,
+  },
+  saveButton: {
+    backgroundColor: colors.primary.teal,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    alignItems: 'center',
+    marginTop: spacing.sm,
+  },
+  saveButtonDisabled: {
+    opacity: 0.7,
+  },
+  saveButtonText: {
+    color: colors.bg.darkest,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/apps/mobile/app/organizations/[id]/waiver.tsx
+++ b/apps/mobile/app/organizations/[id]/waiver.tsx
@@ -27,6 +27,18 @@ export default function OrganizationWaiverScreen() {
   const [isSaving, setIsSaving] = useState(false);
   const [text, setText] = useState('');
   const [currentVersion, setCurrentVersion] = useState<number | null>(null);
+  const [selection, setSelection] = useState({ start: 0, end: 0 });
+
+  // Wraps the selected text in ** markers (rendered bold in the app and PDF),
+  // or inserts a placeholder at the cursor when nothing is selected
+  const handleBold = () => {
+    const { start, end } = selection;
+    if (end > start) {
+      setText(`${text.slice(0, start)}**${text.slice(start, end)}**${text.slice(end)}`);
+    } else {
+      setText(`${text.slice(0, start)}**bold text**${text.slice(start)}`);
+    }
+  };
 
   useEffect(() => {
     load();
@@ -135,17 +147,31 @@ export default function OrganizationWaiverScreen() {
 
             {/* Waiver text editor */}
             <View style={styles.field}>
-              <Text style={styles.label} allowFontScaling={false}>Waiver Text</Text>
+              <View style={styles.editorHeader}>
+                <Text style={styles.label} allowFontScaling={false}>Waiver Text</Text>
+                <TouchableOpacity
+                  style={styles.boldButton}
+                  onPress={handleBold}
+                  accessibilityLabel="Bold selected text"
+                >
+                  <Text style={styles.boldButtonText} allowFontScaling={false}>B</Text>
+                </TouchableOpacity>
+              </View>
               <TextInput
                 style={styles.textArea}
                 value={text}
                 onChangeText={setText}
+                onSelectionChange={(e) => setSelection(e.nativeEvent.selection)}
                 placeholder="Enter the full waiver text members must accept…"
                 placeholderTextColor={colors.text.muted}
                 multiline
                 textAlignVertical="top"
                 allowFontScaling={false}
               />
+              <Text style={styles.formatHint} allowFontScaling={false}>
+                Select text and tap B — or wrap words in ** — to make them bold in
+                the app and the PDF.
+              </Text>
             </View>
 
             {/* Save Button */}
@@ -202,6 +228,31 @@ const styles = StyleSheet.create({
   },
   field: {
     marginBottom: spacing.lg,
+  },
+  editorHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: spacing.xs,
+  },
+  boldButton: {
+    backgroundColor: colors.bg.elevated,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    borderRadius: radius.sm,
+    paddingHorizontal: spacing.sm + 2,
+    paddingVertical: 2,
+  },
+  boldButtonText: {
+    color: colors.text.primary,
+    fontSize: 15,
+    fontWeight: '800',
+  },
+  formatHint: {
+    fontSize: 12,
+    color: colors.text.muted,
+    marginTop: spacing.xs,
+    lineHeight: 16,
   },
   label: {
     fontSize: 12,

--- a/apps/mobile/components/DraggableRoster.tsx
+++ b/apps/mobile/components/DraggableRoster.tsx
@@ -118,13 +118,19 @@ function PlayerCell({
       {/* Skill level bar on inner edge */}
       <SkillBar level={skillInfo.level} color={skillInfo.color} side={side} />
 
-      {/* Line 1: Name */}
+      {/* Line 1: Name (with a subtle warning glyph for players who haven't
+          accepted the org's current waiver - real users only, server-computed) */}
       <Text
         style={[styles.playerName, side === 'left' ? styles.playerNameLeft : styles.playerNameRight]}
         numberOfLines={1}
         allowFontScaling={false}
       >
         {fullName}
+        {registration.hasNotAcceptedWaiver ? (
+          <Text style={styles.waiverWarningGlyph} allowFontScaling={false}>
+            {' ⚠'}
+          </Text>
+        ) : null}
       </Text>
       {/* Line 2: Payment status (organizer only, unpaid) or badges/guest */}
       {showPaymentStatus ? (
@@ -660,6 +666,10 @@ const styles = StyleSheet.create({
   },
   playerNameRight: {
     textAlign: 'left',
+  },
+  waiverWarningGlyph: {
+    fontSize: 12,
+    color: colors.status.warning,
   },
   guestLabel: {
     fontSize: 12,

--- a/apps/mobile/components/DraggableWaitlist.tsx
+++ b/apps/mobile/components/DraggableWaitlist.tsx
@@ -98,6 +98,11 @@ function WaitlistRow({
       <View style={styles.waitlistUserInfo}>
         <Text style={styles.waitlistUserName} allowFontScaling={false}>
           {registration.user.firstName} {registration.user.lastName}
+          {registration.hasNotAcceptedWaiver ? (
+            <Text style={styles.waiverWarningGlyph} allowFontScaling={false}>
+              {' ⚠'}
+            </Text>
+          ) : null}
         </Text>
         <Text style={styles.waitlistUserMeta} allowFontScaling={false}>
           {registration.registeredPosition || 'Skater'}
@@ -440,6 +445,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
     color: colors.text.primary,
+  },
+  waiverWarningGlyph: {
+    fontSize: 13,
+    color: colors.status.warning,
   },
   waitlistUserMeta: {
     fontSize: 13,

--- a/apps/mobile/components/WaiverAcceptanceModal.tsx
+++ b/apps/mobile/components/WaiverAcceptanceModal.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react-native';
 import type { OrganizationWaiver } from '@bhmhockey/shared';
 import { getApiUrl } from '../config/api';
+import { parseWaiverSegments } from '../utils/waiverFormat';
 import { colors, spacing, radius } from '../theme';
 
 // How close to the bottom (px) counts as "scrolled to the bottom"
@@ -129,7 +130,13 @@ export function WaiverAcceptanceModal({
           scrollEventThrottle={100}
         >
           <Text style={styles.waiverText} allowFontScaling={false}>
-            {waiver.text}
+            {parseWaiverSegments(waiver.text).map((segment, i) =>
+              segment.bold ? (
+                <Text key={i} style={styles.waiverTextBold}>{segment.text}</Text>
+              ) : (
+                <Text key={i}>{segment.text}</Text>
+              )
+            )}
           </Text>
         </ScrollView>
 
@@ -223,6 +230,10 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 24,
     color: colors.text.secondary,
+  },
+  waiverTextBold: {
+    fontWeight: '700',
+    color: colors.text.primary,
   },
   footer: {
     padding: spacing.lg,

--- a/apps/mobile/components/WaiverAcceptanceModal.tsx
+++ b/apps/mobile/components/WaiverAcceptanceModal.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Modal,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Linking,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+} from 'react-native';
+import type { OrganizationWaiver } from '@bhmhockey/shared';
+import { getApiUrl } from '../config/api';
+import { colors, spacing, radius } from '../theme';
+
+// How close to the bottom (px) counts as "scrolled to the bottom"
+const SCROLL_BOTTOM_THRESHOLD = 24;
+
+interface WaiverAcceptanceModalProps {
+  visible: boolean;
+  organizationName: string;
+  waiver: OrganizationWaiver;
+  /** Called after the user taps Agree (caller performs the accept API call) */
+  onAgree: () => void | Promise<void>;
+  /**
+   * Dismissible mode (registration flow): renders a Close button and allows
+   * hardware-back dismissal. Omit for the blocking accept-or-leave gate.
+   */
+  onClose?: () => void;
+  /** Blocking gate only: destructive "Leave Organization" secondary action */
+  onLeaveOrganization?: () => void;
+}
+
+/**
+ * Full-screen legal waiver acceptance modal. The Agree button stays disabled
+ * until the user has scrolled the waiver text to the bottom (enabled
+ * immediately when the text fits without scrolling).
+ */
+export function WaiverAcceptanceModal({
+  visible,
+  organizationName,
+  waiver,
+  onAgree,
+  onClose,
+  onLeaveOrganization,
+}: WaiverAcceptanceModalProps) {
+  const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+  const scrollViewHeightRef = useRef(0);
+  const contentHeightRef = useRef(0);
+
+  // A new waiver version (or reopening) requires reading again
+  useEffect(() => {
+    if (visible) {
+      setHasScrolledToBottom(false);
+      setIsProcessing(false);
+    }
+  }, [visible, waiver.id]);
+
+  const maybeEnableWithoutScrolling = () => {
+    // If the content fits in the viewport there is nothing to scroll - enable
+    if (
+      scrollViewHeightRef.current > 0 &&
+      contentHeightRef.current > 0 &&
+      contentHeightRef.current <= scrollViewHeightRef.current
+    ) {
+      setHasScrolledToBottom(true);
+    }
+  };
+
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+    if (layoutMeasurement.height + contentOffset.y >= contentSize.height - SCROLL_BOTTOM_THRESHOLD) {
+      setHasScrolledToBottom(true);
+    }
+  };
+
+  const handleAgree = async () => {
+    setIsProcessing(true);
+    try {
+      await onAgree();
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleViewPdf = () => {
+    // Public endpoint - opens in the browser where it can be viewed/saved
+    Linking.openURL(`${getApiUrl()}/organizations/${waiver.organizationId}/waiver/pdf`);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      onRequestClose={onClose ?? (() => {})}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title} allowFontScaling={false}>
+            Legal Waiver
+          </Text>
+          <Text style={styles.orgName} allowFontScaling={false}>
+            {organizationName}
+          </Text>
+          <Text style={styles.versionLine} allowFontScaling={false}>
+            Version {waiver.version} · {new Date(waiver.createdAt).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </Text>
+        </View>
+
+        <ScrollView
+          style={styles.textScroll}
+          contentContainerStyle={styles.textScrollContent}
+          onLayout={(event) => {
+            scrollViewHeightRef.current = event.nativeEvent.layout.height;
+            maybeEnableWithoutScrolling();
+          }}
+          onContentSizeChange={(_, height) => {
+            contentHeightRef.current = height;
+            maybeEnableWithoutScrolling();
+          }}
+          onScroll={handleScroll}
+          scrollEventThrottle={100}
+        >
+          <Text style={styles.waiverText} allowFontScaling={false}>
+            {waiver.text}
+          </Text>
+        </ScrollView>
+
+        <View style={styles.footer}>
+          <TouchableOpacity onPress={handleViewPdf} style={styles.pdfLink}>
+            <Text style={styles.pdfLinkText} allowFontScaling={false}>
+              View / Save as PDF
+            </Text>
+          </TouchableOpacity>
+
+          {!hasScrolledToBottom && (
+            <Text style={styles.scrollHint} allowFontScaling={false}>
+              Scroll to the bottom to enable Agree
+            </Text>
+          )}
+
+          <TouchableOpacity
+            style={[styles.agreeButton, (!hasScrolledToBottom || isProcessing) && styles.agreeButtonDisabled]}
+            onPress={handleAgree}
+            disabled={!hasScrolledToBottom || isProcessing}
+          >
+            {isProcessing ? (
+              <ActivityIndicator color={colors.bg.darkest} />
+            ) : (
+              <Text style={styles.agreeButtonText} allowFontScaling={false}>
+                I Agree
+              </Text>
+            )}
+          </TouchableOpacity>
+
+          {onLeaveOrganization && (
+            <TouchableOpacity
+              style={styles.leaveButton}
+              onPress={onLeaveOrganization}
+              disabled={isProcessing}
+            >
+              <Text style={styles.leaveButtonText} allowFontScaling={false}>
+                Leave Organization
+              </Text>
+            </TouchableOpacity>
+          )}
+
+          {onClose && (
+            <TouchableOpacity style={styles.closeButton} onPress={onClose} disabled={isProcessing}>
+              <Text style={styles.closeButtonText} allowFontScaling={false}>
+                Not Now
+              </Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: colors.bg.darkest,
+    paddingTop: spacing.xl + spacing.lg,
+  },
+  header: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border.default,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: colors.text.primary,
+  },
+  orgName: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.primary.teal,
+    marginTop: spacing.xs,
+  },
+  versionLine: {
+    fontSize: 13,
+    color: colors.text.muted,
+    marginTop: spacing.xs,
+  },
+  textScroll: {
+    flex: 1,
+  },
+  textScrollContent: {
+    padding: spacing.lg,
+  },
+  waiverText: {
+    fontSize: 15,
+    lineHeight: 24,
+    color: colors.text.secondary,
+  },
+  footer: {
+    padding: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border.default,
+    backgroundColor: colors.bg.dark,
+  },
+  pdfLink: {
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  pdfLinkText: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: colors.primary.teal,
+    textDecorationLine: 'underline',
+  },
+  scrollHint: {
+    fontSize: 13,
+    color: colors.text.muted,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  agreeButton: {
+    backgroundColor: colors.primary.teal,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    alignItems: 'center',
+  },
+  agreeButtonDisabled: {
+    opacity: 0.4,
+  },
+  agreeButtonText: {
+    color: colors.bg.darkest,
+    fontSize: 17,
+    fontWeight: '600',
+  },
+  leaveButton: {
+    marginTop: spacing.md,
+    paddingVertical: spacing.md,
+    borderRadius: radius.md,
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: colors.status.error,
+  },
+  leaveButtonText: {
+    color: colors.status.error,
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  closeButton: {
+    marginTop: spacing.md,
+    paddingVertical: spacing.sm,
+    alignItems: 'center',
+  },
+  closeButtonText: {
+    color: colors.text.muted,
+    fontSize: 15,
+  },
+});

--- a/apps/mobile/components/index.ts
+++ b/apps/mobile/components/index.ts
@@ -34,6 +34,9 @@ export { EnvBanner } from './EnvBanner';
 // Notification components
 export { NotificationItem } from './NotificationItem';
 
+// Waiver components
+export { WaiverAcceptanceModal } from './WaiverAcceptanceModal';
+
 // Roster/Matchup components
 export { DraggableRoster } from './DraggableRoster';
 export { DraggableWaitlist } from './DraggableWaitlist';

--- a/apps/mobile/stores/organizationStore.ts
+++ b/apps/mobile/stores/organizationStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { organizationService } from '@bhmhockey/api-client';
-import type { Organization, OrganizationSubscription, CreateOrganizationRequest, OrganizationMember, AutoRosterMember, Position } from '@bhmhockey/shared';
+import type { Organization, OrganizationSubscription, CreateOrganizationRequest, OrganizationMember, AutoRosterMember, Position, OrganizationWaiver } from '@bhmhockey/shared';
 
 /** Extract message from ApiError objects or Error instances */
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -17,6 +17,8 @@ interface OrganizationState {
   members: OrganizationMember[]; // Members of the org being viewed (admin flows)
   autoRoster: AutoRosterMember[]; // Auto-roster of the org being viewed (admin only)
   autoRosterOrgId: string | null; // Which org the loaded autoRoster belongs to
+  waiver: OrganizationWaiver | null; // Active waiver of the org being viewed (null = none)
+  waiverOrgId: string | null; // Which org the loaded waiver belongs to
   isLoading: boolean;
   error: string | null;
 
@@ -38,6 +40,10 @@ interface OrganizationState {
   addAutoRosterMember: (organizationId: string, userId: string, position: Position) => Promise<boolean>;
   removeAutoRosterMember: (organizationId: string, userId: string) => Promise<boolean>;
   reorderAutoRoster: (organizationId: string, orderedUserIds: string[]) => Promise<boolean>;
+
+  // Waiver actions (fetch for anyone; save is admin only)
+  fetchWaiver: (organizationId: string) => Promise<OrganizationWaiver | null>;
+  saveWaiver: (organizationId: string, text: string) => Promise<boolean>;
 }
 
 export const useOrganizationStore = create<OrganizationState>((set, get) => ({
@@ -47,6 +53,8 @@ export const useOrganizationStore = create<OrganizationState>((set, get) => ({
   members: [],
   autoRoster: [],
   autoRosterOrgId: null,
+  waiver: null,
+  waiverOrgId: null,
   isLoading: false,
   error: null,
 
@@ -222,6 +230,34 @@ export const useOrganizationStore = create<OrganizationState>((set, get) => ({
         autoRoster,
         error: getErrorMessage(error, 'Failed to remove player from auto-roster'),
       });
+      return false;
+    }
+  },
+
+  fetchWaiver: async (organizationId: string) => {
+    try {
+      const waiver = await organizationService.getWaiver(organizationId);
+      set({ waiver, waiverOrgId: organizationId });
+      return waiver;
+    } catch (error) {
+      // 404 = no active waiver; a normal state, not an error
+      if (error && typeof error === 'object' && (error as any).statusCode === 404) {
+        set({ waiver: null, waiverOrgId: organizationId });
+        return null;
+      }
+      set({ error: getErrorMessage(error, 'Failed to load waiver') });
+      return null;
+    }
+  },
+
+  saveWaiver: async (organizationId: string, text: string) => {
+    try {
+      // Returns the new active waiver, or null when cleared/deactivated
+      const waiver = await organizationService.setWaiver(organizationId, text);
+      set({ waiver, waiverOrgId: organizationId });
+      return true;
+    } catch (error) {
+      set({ error: getErrorMessage(error, 'Failed to save waiver') });
       return false;
     }
   },

--- a/apps/mobile/stores/waiverStore.ts
+++ b/apps/mobile/stores/waiverStore.ts
@@ -1,0 +1,86 @@
+import { create } from 'zustand';
+import { organizationService } from '@bhmhockey/api-client';
+import type { PendingWaiver } from '@bhmhockey/shared';
+
+/** Extract message from ApiError objects or Error instances */
+function getErrorMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string') {
+    return (error as any).message || fallback;
+  }
+  return fallback;
+}
+
+interface WaiverState {
+  // Orgs where the user holds an upcoming registration but hasn't accepted the
+  // current waiver. Non-empty => the blocking accept-or-leave gate is shown.
+  pendingWaivers: PendingWaiver[];
+  isFetching: boolean;
+  error: string | null;
+
+  // Actions
+  fetchPendingWaivers: () => Promise<void>;
+  acceptWaiver: (organizationId: string, waiverId: string) => Promise<boolean>;
+  leaveOrganization: (organizationId: string) => Promise<boolean>;
+  reset: () => void;
+}
+
+export const useWaiverStore = create<WaiverState>((set, get) => ({
+  pendingWaivers: [],
+  isFetching: false,
+  error: null,
+
+  // Fetch pending waivers (called on app open, foreground, and after login)
+  fetchPendingWaivers: async () => {
+    if (get().isFetching) {
+      return;
+    }
+    set({ isFetching: true, error: null });
+    try {
+      const pendingWaivers = await organizationService.getPendingWaivers();
+      set({ pendingWaivers, isFetching: false });
+    } catch (error) {
+      // Keep the current queue on error - retried on next foreground
+      set({
+        error: getErrorMessage(error, 'Failed to check pending waivers'),
+        isFetching: false,
+      });
+    }
+  },
+
+  // Accept a specific waiver version; removes the org from the pending queue
+  acceptWaiver: async (organizationId: string, waiverId: string) => {
+    try {
+      await organizationService.acceptWaiver(organizationId, waiverId);
+      set((state) => ({
+        pendingWaivers: state.pendingWaivers.filter((p) => p.organizationId !== organizationId),
+      }));
+      return true;
+    } catch (error) {
+      const message = getErrorMessage(error, 'Failed to accept waiver');
+      // Stale version (admin updated the waiver mid-flow): refresh the queue so
+      // the gate re-presents the latest text (the refresh resets error state,
+      // so set the acceptance error afterwards)
+      await get().fetchPendingWaivers();
+      set({ error: message });
+      return false;
+    }
+  },
+
+  // Leave the org (unsubscribes AND cancels upcoming registrations server-side);
+  // removes the org from the pending queue
+  leaveOrganization: async (organizationId: string) => {
+    try {
+      await organizationService.leaveOrganization(organizationId);
+      set((state) => ({
+        pendingWaivers: state.pendingWaivers.filter((p) => p.organizationId !== organizationId),
+      }));
+      return true;
+    } catch (error) {
+      set({ error: getErrorMessage(error, 'Failed to leave organization') });
+      return false;
+    }
+  },
+
+  // Reset store (on logout)
+  reset: () => set({ pendingWaivers: [], isFetching: false, error: null }),
+}));

--- a/apps/mobile/utils/waiverFormat.ts
+++ b/apps/mobile/utils/waiverFormat.ts
@@ -1,0 +1,30 @@
+export interface WaiverTextSegment {
+  text: string;
+  bold: boolean;
+}
+
+/**
+ * Parses waiver text with **bold** markers into renderable segments.
+ * The same rule is applied server-side when generating the waiver PDF
+ * (OrganizationWaiverService.ParseBoldSegments) — keep them in sync.
+ * An unmatched trailing ** is rendered literally rather than bolding
+ * the rest of the document.
+ */
+export function parseWaiverSegments(text: string): WaiverTextSegment[] {
+  const parts = text.split('**');
+  if (parts.length === 1) {
+    return [{ text, bold: false }];
+  }
+
+  const unbalanced = parts.length % 2 === 0;
+  const segments: WaiverTextSegment[] = [];
+  parts.forEach((part, i) => {
+    const isLast = i === parts.length - 1;
+    if (unbalanced && isLast) {
+      segments.push({ text: `**${part}`, bold: false });
+    } else if (part.length > 0) {
+      segments.push({ text: part, bold: i % 2 === 1 });
+    }
+  });
+  return segments;
+}

--- a/packages/api-client/__tests__/services/organizations.test.ts
+++ b/packages/api-client/__tests__/services/organizations.test.ts
@@ -102,3 +102,87 @@ describe('organizationService auto-roster', () => {
     });
   });
 });
+
+const mockWaiver = {
+  id: 'waiver-1',
+  organizationId: 'org-1',
+  text: 'You play at your own risk.',
+  version: 2,
+  createdAt: '2026-07-16T00:00:00Z',
+};
+
+describe('organizationService waivers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    initializeApiClient({ baseURL: 'http://localhost:5001/api' });
+  });
+
+  describe('getWaiver', () => {
+    it('fetches the current waiver from the correct endpoint', async () => {
+      mockGet.mockResolvedValueOnce({ data: mockWaiver });
+
+      const result = await organizationService.getWaiver('org-1');
+
+      expect(mockGet).toHaveBeenCalledWith('/organizations/org-1/waiver');
+      expect(result).toEqual(mockWaiver);
+    });
+  });
+
+  describe('setWaiver', () => {
+    it('puts the text and returns the new active waiver', async () => {
+      mockPut.mockResolvedValueOnce({ data: { waiver: mockWaiver } });
+
+      const result = await organizationService.setWaiver('org-1', 'You play at your own risk.');
+
+      expect(mockPut).toHaveBeenCalledWith('/organizations/org-1/waiver', {
+        text: 'You play at your own risk.',
+      });
+      expect(result).toEqual(mockWaiver);
+    });
+
+    it('returns null when the waiver was cleared', async () => {
+      mockPut.mockResolvedValueOnce({ data: { waiver: null } });
+
+      const result = await organizationService.setWaiver('org-1', '');
+
+      expect(mockPut).toHaveBeenCalledWith('/organizations/org-1/waiver', { text: '' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('acceptWaiver', () => {
+    it('posts the specific waiver id to the accept endpoint', async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      await organizationService.acceptWaiver('org-1', 'waiver-1');
+
+      expect(mockPost).toHaveBeenCalledWith('/organizations/org-1/waiver/accept', {
+        waiverId: 'waiver-1',
+      });
+    });
+  });
+
+  describe('getPendingWaivers', () => {
+    it('fetches pending waivers for the current user', async () => {
+      const pending = [
+        { organizationId: 'org-1', organizationName: 'Test Org', waiver: mockWaiver },
+      ];
+      mockGet.mockResolvedValueOnce({ data: pending });
+
+      const result = await organizationService.getPendingWaivers();
+
+      expect(mockGet).toHaveBeenCalledWith('/users/me/pending-waivers');
+      expect(result).toEqual(pending);
+    });
+  });
+
+  describe('leaveOrganization', () => {
+    it('posts to the leave endpoint', async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      await organizationService.leaveOrganization('org-1');
+
+      expect(mockPost).toHaveBeenCalledWith('/organizations/org-1/leave');
+    });
+  });
+});

--- a/packages/api-client/src/services/organizations.ts
+++ b/packages/api-client/src/services/organizations.ts
@@ -7,7 +7,12 @@ import type {
   UpdateOrganizationRequest,
   AddAdminRequest,
   AutoRosterMember,
-  AddAutoRosterMemberRequest
+  AddAutoRosterMemberRequest,
+  OrganizationWaiver,
+  SetOrganizationWaiverRequest,
+  SetOrganizationWaiverResponse,
+  AcceptWaiverRequest,
+  PendingWaiver
 } from '@bhmhockey/shared';
 import { apiClient } from '../client';
 
@@ -158,5 +163,54 @@ export const organizationService = {
       { orderedUserIds }
     );
     return response.data;
+  },
+
+  // Waiver methods
+
+  /**
+   * Get the organization's current active waiver (404 when none)
+   */
+  async getWaiver(organizationId: string): Promise<OrganizationWaiver> {
+    const response = await apiClient.instance.get<OrganizationWaiver>(`/organizations/${organizationId}/waiver`);
+    return response.data;
+  },
+
+  /**
+   * Set the organization's waiver (admin only). Creates the next immutable
+   * version; empty text deactivates the waiver. Returns the active waiver
+   * after the save, or null when the waiver was cleared.
+   */
+  async setWaiver(organizationId: string, text: string): Promise<OrganizationWaiver | null> {
+    const request: SetOrganizationWaiverRequest = { text };
+    const response = await apiClient.instance.put<SetOrganizationWaiverResponse>(
+      `/organizations/${organizationId}/waiver`,
+      request
+    );
+    return response.data.waiver;
+  },
+
+  /**
+   * Accept a SPECIFIC waiver version (400 when the id is stale)
+   */
+  async acceptWaiver(organizationId: string, waiverId: string): Promise<void> {
+    const request: AcceptWaiverRequest = { waiverId };
+    await apiClient.instance.post(`/organizations/${organizationId}/waiver/accept`, request);
+  },
+
+  /**
+   * Orgs where the current user holds an upcoming registration but has not
+   * accepted the current waiver (powers the blocking accept-or-leave gate)
+   */
+  async getPendingWaivers(): Promise<PendingWaiver[]> {
+    const response = await apiClient.instance.get<PendingWaiver[]>('/users/me/pending-waivers');
+    return response.data;
+  },
+
+  /**
+   * Leave an organization: unsubscribe AND cancel upcoming registrations in
+   * the org's events (waitlist promotions fire server-side as usual)
+   */
+  async leaveOrganization(organizationId: string): Promise<void> {
+    await apiClient.instance.post(`/organizations/${organizationId}/leave`);
   },
 };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -97,6 +97,43 @@ export interface OrganizationMember {
   isAdmin: boolean;  // True if this member is an admin of the organization
   badges?: UserBadgeDto[];  // Top 3 badges by displayOrder
   totalBadgeCount?: number;  // Total badges user has earned
+  hasAcceptedCurrentWaiver?: boolean | null;  // null when the org has no active waiver
+}
+
+// ============================================
+// Organization Waiver Types
+// ============================================
+
+// A single (immutable) waiver version - the org's current active waiver
+export interface OrganizationWaiver {
+  id: string;
+  organizationId: string;
+  text: string;
+  version: number;  // Per-org incrementing, starting at 1
+  createdAt: string;
+}
+
+// PUT waiver request - trimmed server-side; empty text deactivates the waiver
+export interface SetOrganizationWaiverRequest {
+  text: string;
+}
+
+// PUT waiver response - waiver is null when no active waiver remains (cleared)
+export interface SetOrganizationWaiverResponse {
+  waiver: OrganizationWaiver | null;
+}
+
+// Accept a SPECIFIC waiver version (stale ids are rejected with 400)
+export interface AcceptWaiverRequest {
+  waiverId: string;
+}
+
+// Blocking-gate entry: an org where the current user holds an upcoming
+// registration but has not accepted the current active waiver
+export interface PendingWaiver {
+  organizationId: string;
+  organizationName: string;
+  waiver: OrganizationWaiver;
 }
 
 export type SkillLevel = 'Gold' | 'Silver' | 'Bronze' | 'D-League';
@@ -254,6 +291,9 @@ export interface EventDto {
   showWaitlistBeforePublish: boolean;  // Registered/waitlisted viewers can see the ordered waitlist before publish
   // Pay-eligibility for the current user's waitlisted registration on paid events
   myWaitlistPaymentEligible?: boolean | null;  // null when not applicable (not waitlisted or free event)
+  // Waiver gate for the current user: org event + active waiver + not accepted
+  // (same rule for everyone with a real account, including managers)
+  requiresWaiverAcceptance: boolean;
   // Slot position labels (organizer feature)
   slotPositionLabels?: Record<number, string>; // Maps slot index to position label (e.g., {1: "C", 2: "LW"})
   // GroupMe chat link, resolved server-side at read time: event override wins, else org's link
@@ -283,6 +323,8 @@ export interface EventRegistrationDto {
   promotedAt?: string;           // When user was promoted from waitlist (ISO date string)
   paymentDeadlineAt?: string;    // Deadline to pay after promotion (ISO date string)
   isWaitlisted: boolean;         // True if Status == "Waitlisted"
+  // True ONLY when: org event + active waiver + real user (not ghost) + no current acceptance
+  hasNotAcceptedWaiver?: boolean;
 }
 
 // Event request types


### PR DESCRIPTION
## Summary

Organizations can optionally define a legal waiver. Users must accept the current version to self-register for that org's events, anyone holding a registration who isn't current hits a blocking accept-or-leave gate, and the waiver is viewable/saveable as a PDF.

## Design

- **Versioned + immutable for legal defensibility**: `OrganizationWaivers` rows are never updated or deleted — every edit creates a new version, and `WaiverAcceptances` records exactly which version each user accepted, when. Waiver rows use SetNull on the authoring user so legal records can never be cascade-deleted. Acceptance is org-level (covers all the org's events until the text changes). Clearing the text disables all gating while preserving history. Saving identical text is a no-op so admins can't accidentally re-gate every member.
- **Two server-enforced gates**: self-registration on an org event 400s without current acceptance (mobile shows the waiver full-screen first — Agree is disabled until scrolled to the bottom — then continues registering in the same gesture). Separately, any user holding an active registration on an upcoming event without current acceptance gets a non-dismissible accept-or-leave flow on app open/foreground; "Leave Organization" (with a registrations-will-be-cancelled warning) unsubscribes and cancels their upcoming registrations via the existing cancellation logic, past events untouched.
- **Organizer-initiated placements are never blocked at placement time** (auto-roster, manual adds) — the blocking gate catches those users. Ghost players are exempt from everything.
- **Organizer visibility**: org member list shows per-member waiver badges plus an "X accepted · Y not yet" summary; event rosters flag only unaccepted players. All hidden when no active waiver.
- **PDF**: server-rendered via QuestPDF (new NuGet dependency, pinned 2024.12.3, Community license configured) at a public endpoint — waivers aren't secrets, and this keeps the mobile app free of new native modules. Bold supported via **markers**: a B toolbar button in the admin editor, mirrored parsers render bold in the acceptance modal and SemiBold in the PDF.
- **No notifications** anywhere in this feature, by explicit design (the organizer handles all outreach).

## Testing

- API suite: 1007 → 1077 (versioning/immutability, active-waiver semantics, acceptance idempotency + stale-version rejection, both gates, ghost/organizer-path exemptions, pending-waivers correctness incl. past-event exclusion, leave-org cancellation + promotion side effects, member/roster flags, PDF 200/404 + bold rendering, authz, bold parser cases)
- Frontend: api-client 33→39, mobile 90→110, shared 41; mobile type-check clean
- Live E2E: 8 scenarios against a throwaway org, incl. PDF byte verification, version-row immutability checks, and the leave-path promoting a payment-verified waitlister via existing side effects; cleaned up afterward
- Manually tested in the iOS simulator by @auc0le (editor, accept flow, PDF, blocking gate, leave path, member statuses, bold)

Additive-only migration (two tables). DTOs mirrored in `@bhmhockey/shared`. No `UserDto` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)