### PR TITLE
Add signature fields to waiver acceptance with membership-wide gating

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
@@ -594,7 +594,7 @@ public class OrganizationsControllerTests
         // Arrange
         SetupAuthenticatedUser(_testUserId);
         var orgId = Guid.NewGuid();
-        var request = new AcceptWaiverRequest(Guid.NewGuid(), "Test Participant", DateTime.UtcNow.Date);
+        var request = new AcceptWaiverRequest(Guid.NewGuid(), "Test Participant");
 
         // Act
         var result = await _controller.AcceptWaiver(orgId, request);
@@ -611,7 +611,7 @@ public class OrganizationsControllerTests
         // Arrange
         SetupAuthenticatedUser(_testUserId);
         var orgId = Guid.NewGuid();
-        var request = new AcceptWaiverRequest(Guid.NewGuid(), "Test Participant", DateTime.UtcNow.Date);
+        var request = new AcceptWaiverRequest(Guid.NewGuid(), "Test Participant");
         _mockWaiverService.Setup(s => s.AcceptWaiverAsync(orgId, request, _testUserId))
             .ThrowsAsync(new InvalidOperationException("This waiver version is no longer current."));
 
@@ -628,7 +628,7 @@ public class OrganizationsControllerTests
         // Arrange
         SetupAuthenticatedUser(_testUserId);
         var orgId = Guid.NewGuid();
-        var request = new AcceptWaiverRequest(Guid.NewGuid(), "", DateTime.UtcNow.Date);
+        var request = new AcceptWaiverRequest(Guid.NewGuid(), "");
         _mockWaiverService.Setup(s => s.AcceptWaiverAsync(orgId, request, _testUserId))
             .ThrowsAsync(new InvalidOperationException("Printed name is required."));
 

--- a/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/OrganizationsControllerTests.cs
@@ -594,14 +594,15 @@ public class OrganizationsControllerTests
         // Arrange
         SetupAuthenticatedUser(_testUserId);
         var orgId = Guid.NewGuid();
-        var waiverId = Guid.NewGuid();
+        var request = new AcceptWaiverRequest(Guid.NewGuid(), "Test Participant", DateTime.UtcNow.Date);
 
         // Act
-        var result = await _controller.AcceptWaiver(orgId, new AcceptWaiverRequest(waiverId));
+        var result = await _controller.AcceptWaiver(orgId, request);
 
         // Assert
         result.Should().BeOfType<OkObjectResult>();
-        _mockWaiverService.Verify(s => s.AcceptWaiverAsync(orgId, waiverId, _testUserId), Times.Once);
+        // The full request (waiver id + signature fields) is passed through
+        _mockWaiverService.Verify(s => s.AcceptWaiverAsync(orgId, request, _testUserId), Times.Once);
     }
 
     [Fact]
@@ -610,15 +611,33 @@ public class OrganizationsControllerTests
         // Arrange
         SetupAuthenticatedUser(_testUserId);
         var orgId = Guid.NewGuid();
-        var staleWaiverId = Guid.NewGuid();
-        _mockWaiverService.Setup(s => s.AcceptWaiverAsync(orgId, staleWaiverId, _testUserId))
+        var request = new AcceptWaiverRequest(Guid.NewGuid(), "Test Participant", DateTime.UtcNow.Date);
+        _mockWaiverService.Setup(s => s.AcceptWaiverAsync(orgId, request, _testUserId))
             .ThrowsAsync(new InvalidOperationException("This waiver version is no longer current."));
 
         // Act
-        var result = await _controller.AcceptWaiver(orgId, new AcceptWaiverRequest(staleWaiverId));
+        var result = await _controller.AcceptWaiver(orgId, request);
 
         // Assert
         result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task AcceptWaiver_WithValidationFailure_Returns400WithMessage()
+    {
+        // Arrange
+        SetupAuthenticatedUser(_testUserId);
+        var orgId = Guid.NewGuid();
+        var request = new AcceptWaiverRequest(Guid.NewGuid(), "", DateTime.UtcNow.Date);
+        _mockWaiverService.Setup(s => s.AcceptWaiverAsync(orgId, request, _testUserId))
+            .ThrowsAsync(new InvalidOperationException("Printed name is required."));
+
+        // Act
+        var result = await _controller.AcceptWaiver(orgId, request);
+
+        // Assert
+        var badRequest = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        badRequest.Value.Should().BeEquivalentTo(new { message = "Printed name is required." });
     }
 
     [Fact]

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -4577,7 +4577,7 @@ public class EventServiceTests : IDisposable
         var org = await CreateTestOrganization(creator.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
         var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test User"), player.Id);
 
         // Act
         var result = await _sut.RegisterAsync(evt.Id, player.Id);
@@ -4628,7 +4628,7 @@ public class EventServiceTests : IDisposable
         var player = await CreateTestUser("player@example.com");
         var org = await CreateTestOrganization(creator.Id);
         var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant"), player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test User"), player.Id);
         await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
         var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
 
@@ -4742,7 +4742,7 @@ public class EventServiceTests : IDisposable
         (await _sut.GetByIdAsync(evt.Id, creator.Id))!.RequiresWaiverAcceptance.Should().BeTrue();
 
         // Accepted -> false
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test User"), player.Id);
         (await _sut.GetByIdAsync(evt.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeFalse();
 
         // Anonymous -> false
@@ -4783,7 +4783,7 @@ public class EventServiceTests : IDisposable
         await CreateRegistration(evt.Id, accepted.Id);
         await CreateRegistration(evt.Id, unaccepted.Id);
         await CreateRegistration(evt.Id, ghost.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), accepted.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test User"), accepted.Id);
 
         // Act
         var registrations = await _sut.GetRegistrationsAsync(evt.Id);

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -4577,7 +4577,7 @@ public class EventServiceTests : IDisposable
         var org = await CreateTestOrganization(creator.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
         var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
-        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), player.Id);
 
         // Act
         var result = await _sut.RegisterAsync(evt.Id, player.Id);
@@ -4628,7 +4628,7 @@ public class EventServiceTests : IDisposable
         var player = await CreateTestUser("player@example.com");
         var org = await CreateTestOrganization(creator.Id);
         var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant", DateTime.UtcNow.Date), player.Id);
         await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
         var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
 
@@ -4742,7 +4742,7 @@ public class EventServiceTests : IDisposable
         (await _sut.GetByIdAsync(evt.Id, creator.Id))!.RequiresWaiverAcceptance.Should().BeTrue();
 
         // Accepted -> false
-        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), player.Id);
         (await _sut.GetByIdAsync(evt.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeFalse();
 
         // Anonymous -> false
@@ -4783,7 +4783,7 @@ public class EventServiceTests : IDisposable
         await CreateRegistration(evt.Id, accepted.Id);
         await CreateRegistration(evt.Id, unaccepted.Id);
         await CreateRegistration(evt.Id, ghost.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, accepted.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), accepted.Id);
 
         // Act
         var registrations = await _sut.GetRegistrationsAsync(evt.Id);

--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -4577,7 +4577,7 @@ public class EventServiceTests : IDisposable
         var org = await CreateTestOrganization(creator.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
         var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), player.Id);
 
         // Act
         var result = await _sut.RegisterAsync(evt.Id, player.Id);
@@ -4628,7 +4628,7 @@ public class EventServiceTests : IDisposable
         var player = await CreateTestUser("player@example.com");
         var org = await CreateTestOrganization(creator.Id);
         var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant", DateTime.UtcNow.Date), player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant"), player.Id);
         await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
         var evt = await CreateTestEvent(creator.Id, org.Id, cost: 0);
 
@@ -4742,7 +4742,7 @@ public class EventServiceTests : IDisposable
         (await _sut.GetByIdAsync(evt.Id, creator.Id))!.RequiresWaiverAcceptance.Should().BeTrue();
 
         // Accepted -> false
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), player.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), player.Id);
         (await _sut.GetByIdAsync(evt.Id, player.Id))!.RequiresWaiverAcceptance.Should().BeFalse();
 
         // Anonymous -> false
@@ -4783,7 +4783,7 @@ public class EventServiceTests : IDisposable
         await CreateRegistration(evt.Id, accepted.Id);
         await CreateRegistration(evt.Id, unaccepted.Id);
         await CreateRegistration(evt.Id, ghost.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), accepted.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), accepted.Id);
 
         // Act
         var registrations = await _sut.GetRegistrationsAsync(evt.Id);

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -1265,6 +1265,28 @@ public class OrganizationServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetMembersAsync_NonAdminRequester_NeverSeesWaiverFlags()
+    {
+        // Arrange - active waiver with a mix of accepted/unaccepted members
+        var creator = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var otherMember = await CreateTestUser("other@example.com");
+        var org = await CreateTestOrganization(creator.Id);
+        await CreateSubscription(org.Id, creator.Id);
+        await CreateSubscription(org.Id, member.Id);
+        await CreateSubscription(org.Id, otherMember.Id);
+        var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "John Doe"), member.Id);
+
+        // Act - a plain subscriber (not an admin) requests the member list
+        var members = await _sut.GetMembersAsync(org.Id, member.Id);
+
+        // Assert - waiver acceptance status is admin-only; every flag is null
+        members.Should().NotBeEmpty();
+        members.Should().OnlyContain(m => m.HasAcceptedCurrentWaiver == null);
+    }
+
+    [Fact]
     public async Task GetMembersAsync_NewVersion_ResetsAcceptanceFlags()
     {
         // Arrange

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -1233,7 +1233,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, acceptedMember.Id);
         await CreateSubscription(org.Id, unacceptedMember.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, acceptedMember.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), acceptedMember.Id);
 
         // Act
         var members = await _sut.GetMembersAsync(org.Id, creator.Id);
@@ -1254,7 +1254,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, creator.Id);
         await CreateSubscription(org.Id, member.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, waiver!.Id, member.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), member.Id);
         await _waiverService.SetWaiverAsync(org.Id, "", creator.Id);
 
         // Act
@@ -1274,7 +1274,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, creator.Id);
         await CreateSubscription(org.Id, member.Id);
         var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, v1!.Id, member.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant", DateTime.UtcNow.Date), member.Id);
         await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
 
         // Act

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -1233,7 +1233,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, acceptedMember.Id);
         await CreateSubscription(org.Id, unacceptedMember.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), acceptedMember.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "John Doe"), acceptedMember.Id);
 
         // Act
         var members = await _sut.GetMembersAsync(org.Id, creator.Id);
@@ -1254,7 +1254,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, creator.Id);
         await CreateSubscription(org.Id, member.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), member.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "John Doe"), member.Id);
         await _waiverService.SetWaiverAsync(org.Id, "", creator.Id);
 
         // Act
@@ -1274,7 +1274,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, creator.Id);
         await CreateSubscription(org.Id, member.Id);
         var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant"), member.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "John Doe"), member.Id);
         await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
 
         // Act

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -1233,7 +1233,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, acceptedMember.Id);
         await CreateSubscription(org.Id, unacceptedMember.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), acceptedMember.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), acceptedMember.Id);
 
         // Act
         var members = await _sut.GetMembersAsync(org.Id, creator.Id);
@@ -1254,7 +1254,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, creator.Id);
         await CreateSubscription(org.Id, member.Id);
         var waiver = await _waiverService.SetWaiverAsync(org.Id, "waiver text", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant", DateTime.UtcNow.Date), member.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(waiver!.Id, "Test Participant"), member.Id);
         await _waiverService.SetWaiverAsync(org.Id, "", creator.Id);
 
         // Act
@@ -1274,7 +1274,7 @@ public class OrganizationServiceTests : IDisposable
         await CreateSubscription(org.Id, creator.Id);
         await CreateSubscription(org.Id, member.Id);
         var v1 = await _waiverService.SetWaiverAsync(org.Id, "v1", creator.Id);
-        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant", DateTime.UtcNow.Date), member.Id);
+        await _waiverService.AcceptWaiverAsync(org.Id, new AcceptWaiverRequest(v1!.Id, "Test Participant"), member.Id);
         await _waiverService.SetWaiverAsync(org.Id, "v2", creator.Id);
 
         // Act

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
@@ -1,4 +1,5 @@
 using BHMHockey.Api.Data;
+using BHMHockey.Api.Models.DTOs;
 using BHMHockey.Api.Models.Entities;
 using BHMHockey.Api.Services;
 using FluentAssertions;
@@ -128,6 +129,30 @@ public class OrganizationWaiverServiceTests : IDisposable
         _context.EventRegistrations.Add(registration);
         await _context.SaveChangesAsync();
         return registration;
+    }
+
+    /// <summary>
+    /// Minimal valid acceptance request: adult signature fields only.
+    /// </summary>
+    private static AcceptWaiverRequest ValidAcceptRequest(Guid waiverId, string participantName = "Test Participant")
+    {
+        return new AcceptWaiverRequest(waiverId, participantName, DateTime.UtcNow.Date);
+    }
+
+    /// <summary>
+    /// Valid acceptance request with the full Parent/Guardian section filled in.
+    /// </summary>
+    private static AcceptWaiverRequest MinorAcceptRequest(Guid waiverId)
+    {
+        return new AcceptWaiverRequest(
+            waiverId,
+            "Guardian As Participant",
+            DateTime.UtcNow.Date,
+            MinorParticipantName: "Minor Player",
+            MinorDateOfBirth: DateTime.UtcNow.Date.AddYears(-12),
+            GuardianName: "Parent Guardian",
+            GuardianSignature: "Parent Guardian",
+            GuardianDate: DateTime.UtcNow.Date);
     }
 
     #endregion
@@ -315,7 +340,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         (await _sut.IsAcceptanceRequiredAsync(org.Id, player.Id)).Should().BeTrue();
 
         // Accepted -> not required
-        await _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(v1!.Id), player.Id);
         (await _sut.IsAcceptanceRequiredAsync(org.Id, player.Id)).Should().BeFalse();
 
         // New version -> required again
@@ -339,7 +364,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var org = await CreateTestOrganization(admin.Id);
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
 
-        await _sut.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(waiver!.Id), player.Id);
 
         var acceptance = await _context.WaiverAcceptances
             .FirstOrDefaultAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
@@ -355,8 +380,8 @@ public class OrganizationWaiverServiceTests : IDisposable
         var org = await CreateTestOrganization(admin.Id);
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
 
-        await _sut.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
-        await _sut.AcceptWaiverAsync(org.Id, waiver.Id, player.Id); // No throw
+        await _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(waiver!.Id), player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(waiver.Id), player.Id); // No throw
 
         (await _context.WaiverAcceptances.CountAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id))
             .Should().Be(1);
@@ -371,7 +396,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
         await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
 
-        var act = () => _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+        var act = () => _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(v1!.Id), player.Id);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*no longer current*");
@@ -387,7 +412,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
         await _sut.SetWaiverAsync(org.Id, "", admin.Id);
 
-        var act = () => _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+        var act = () => _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(v1!.Id), player.Id);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
     }
@@ -402,9 +427,277 @@ public class OrganizationWaiverServiceTests : IDisposable
         var waiverA = await _sut.SetWaiverAsync(orgA.Id, "A v1", admin.Id);
         await _sut.SetWaiverAsync(orgB.Id, "B v1", admin.Id);
 
-        var act = () => _sut.AcceptWaiverAsync(orgB.Id, waiverA!.Id, player.Id);
+        var act = () => _sut.AcceptWaiverAsync(orgB.Id, ValidAcceptRequest(waiverA!.Id), player.Id);
 
         await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    #endregion
+
+    #region Signature Field Tests
+
+    [Fact]
+    public async Task AcceptWaiverAsync_AdultOnly_StoresParticipantFieldsAndLeavesMinorFieldsNull()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var today = DateTime.UtcNow.Date;
+
+        await _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater", today), player.Id);
+
+        var acceptance = await _context.WaiverAcceptances
+            .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
+        acceptance.ParticipantName.Should().Be("Jane Skater");
+        acceptance.ParticipantDate.Should().Be(today);
+        acceptance.ParticipantDate!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        acceptance.MinorParticipantName.Should().BeNull();
+        acceptance.MinorDateOfBirth.Should().BeNull();
+        acceptance.GuardianName.Should().BeNull();
+        acceptance.GuardianSignature.Should().BeNull();
+        acceptance.GuardianDate.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_FullMinorSection_StoresAllSignatureFields()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var request = MinorAcceptRequest(waiver!.Id);
+
+        await _sut.AcceptWaiverAsync(org.Id, request, player.Id);
+
+        var acceptance = await _context.WaiverAcceptances
+            .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
+        acceptance.ParticipantName.Should().Be(request.ParticipantName);
+        acceptance.ParticipantDate.Should().Be(request.ParticipantDate);
+        acceptance.MinorParticipantName.Should().Be(request.MinorParticipantName);
+        acceptance.MinorDateOfBirth.Should().Be(request.MinorDateOfBirth);
+        acceptance.GuardianName.Should().Be(request.GuardianName);
+        acceptance.GuardianSignature.Should().Be(request.GuardianSignature);
+        acceptance.GuardianDate.Should().Be(request.GuardianDate);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AcceptWaiverAsync_MissingOrBlankParticipantName_Throws(string? participantName)
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, participantName, DateTime.UtcNow.Date), player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Printed name is required.");
+        (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_MissingParticipantDate_Throws()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater", null), player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Date is required.");
+        (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_ParticipantNameTooLong_Throws()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, new string('x', 201), DateTime.UtcNow.Date), player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*200 characters or fewer*");
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_TrimsSignatureStrings()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var today = DateTime.UtcNow.Date;
+
+        await _sut.AcceptWaiverAsync(
+            org.Id,
+            new AcceptWaiverRequest(
+                waiver!.Id, "  Jane Skater  ", today,
+                MinorParticipantName: " Minor Player ",
+                MinorDateOfBirth: today.AddYears(-12),
+                GuardianName: " Parent Guardian ",
+                GuardianSignature: " Parent Guardian ",
+                GuardianDate: today),
+            player.Id);
+
+        var acceptance = await _context.WaiverAcceptances
+            .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
+        acceptance.ParticipantName.Should().Be("Jane Skater");
+        acceptance.MinorParticipantName.Should().Be("Minor Player");
+        acceptance.GuardianName.Should().Be("Parent Guardian");
+        acceptance.GuardianSignature.Should().Be("Parent Guardian");
+    }
+
+    // All-or-nothing: each single filled minor field must reject the request
+    [Theory]
+    [InlineData("minorName")]
+    [InlineData("minorDob")]
+    [InlineData("guardianName")]
+    [InlineData("guardianSignature")]
+    [InlineData("guardianDate")]
+    public async Task AcceptWaiverAsync_PartialMinorSection_Throws(string filledField)
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var today = DateTime.UtcNow.Date;
+        var request = new AcceptWaiverRequest(
+            waiver!.Id, "Jane Skater", today,
+            MinorParticipantName: filledField == "minorName" ? "Minor Player" : null,
+            MinorDateOfBirth: filledField == "minorDob" ? today.AddYears(-12) : null,
+            GuardianName: filledField == "guardianName" ? "Parent Guardian" : null,
+            GuardianSignature: filledField == "guardianSignature" ? "Parent Guardian" : null,
+            GuardianDate: filledField == "guardianDate" ? today : null);
+
+        var act = () => _sut.AcceptWaiverAsync(org.Id, request, player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*all-or-nothing*");
+        (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_WhitespaceOnlyMinorSection_TreatedAsEmpty()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        // Whitespace-only strings do not activate the all-or-nothing group
+        await _sut.AcceptWaiverAsync(
+            org.Id,
+            new AcceptWaiverRequest(
+                waiver!.Id, "Jane Skater", DateTime.UtcNow.Date,
+                MinorParticipantName: "   ",
+                GuardianName: " "),
+            player.Id);
+
+        var acceptance = await _context.WaiverAcceptances
+            .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
+        acceptance.MinorParticipantName.Should().BeNull();
+        acceptance.GuardianName.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(0)]   // today is not "in the past"
+    [InlineData(30)]  // future date
+    public async Task AcceptWaiverAsync_MinorDateOfBirthNotInPast_Throws(int daysFromToday)
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var request = MinorAcceptRequest(waiver!.Id) with
+        {
+            MinorDateOfBirth = DateTime.UtcNow.Date.AddDays(daysFromToday)
+        };
+
+        var act = () => _sut.AcceptWaiverAsync(org.Id, request, player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*date of birth must be in the past*");
+        (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_ReacceptWithDifferentFields_PreservesOriginalRow()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        var firstDate = DateTime.UtcNow.Date.AddDays(-1);
+
+        await _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Original Name", firstDate), player.Id);
+        // Re-accept the same version with different signature details
+        await _sut.AcceptWaiverAsync(
+            org.Id, MinorAcceptRequest(waiver.Id), player.Id);
+
+        // Immutable audit record: still one row, exactly as first recorded
+        var acceptances = await _context.WaiverAcceptances
+            .Where(a => a.WaiverId == waiver.Id && a.UserId == player.Id)
+            .ToListAsync();
+        acceptances.Should().HaveCount(1);
+        acceptances[0].ParticipantName.Should().Be("Original Name");
+        acceptances[0].ParticipantDate.Should().Be(firstDate);
+        acceptances[0].MinorParticipantName.Should().BeNull();
+        acceptances[0].GuardianSignature.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_NewVersion_RecordsNewSignatureFieldsAndKeepsOldRow()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        await _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(v1!.Id, "Old Name", DateTime.UtcNow.Date.AddDays(-30)), player.Id);
+
+        var v2 = await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
+        await _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(v2!.Id, "New Name", DateTime.UtcNow.Date), player.Id);
+
+        var oldRow = await _context.WaiverAcceptances.SingleAsync(a => a.WaiverId == v1.Id && a.UserId == player.Id);
+        var newRow = await _context.WaiverAcceptances.SingleAsync(a => a.WaiverId == v2.Id && a.UserId == player.Id);
+        oldRow.ParticipantName.Should().Be("Old Name");
+        newRow.ParticipantName.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_UnspecifiedKindDates_NormalizedToUtcMidnight()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+        // JSON date-only values ("2026-07-21") bind with Kind=Unspecified and may
+        // carry a time component from other clients - both must be normalized
+        var unspecified = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddHours(14), DateTimeKind.Unspecified);
+
+        await _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater", unspecified), player.Id);
+
+        var acceptance = await _context.WaiverAcceptances
+            .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
+        acceptance.ParticipantDate.Should().Be(unspecified.Date);
+        acceptance.ParticipantDate!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        acceptance.ParticipantDate.Value.TimeOfDay.Should().Be(TimeSpan.Zero);
     }
 
     #endregion
@@ -454,7 +747,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var waiver = await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
         var evt = await CreateTestEvent(admin.Id, org.Id);
         await CreateRegistration(evt.Id, player.Id);
-        await _sut.AcceptWaiverAsync(org.Id, waiver!.Id, player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(waiver!.Id), player.Id);
 
         var pending = await _sut.GetPendingWaiversAsync(player.Id);
 
@@ -470,7 +763,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
         var evt = await CreateTestEvent(admin.Id, org.Id);
         await CreateRegistration(evt.Id, player.Id);
-        await _sut.AcceptWaiverAsync(org.Id, v1!.Id, player.Id);
+        await _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(v1!.Id), player.Id);
 
         var v2 = await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
         var pending = await _sut.GetPendingWaiversAsync(player.Id);

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
@@ -134,7 +134,7 @@ public class OrganizationWaiverServiceTests : IDisposable
     /// <summary>
     /// Minimal valid acceptance request: adult signature fields only.
     /// </summary>
-    private static AcceptWaiverRequest ValidAcceptRequest(Guid waiverId, string participantName = "Test Participant")
+    private static AcceptWaiverRequest ValidAcceptRequest(Guid waiverId, string participantName = "Test User")
     {
         return new AcceptWaiverRequest(waiverId, participantName);
     }
@@ -146,7 +146,7 @@ public class OrganizationWaiverServiceTests : IDisposable
     {
         return new AcceptWaiverRequest(
             waiverId,
-            "Guardian As Participant",
+            "Test User",
             MinorParticipantName: "Minor Player",
             MinorDateOfBirth: DateTime.UtcNow.Date.AddYears(-12),
             GuardianName: "Parent Guardian",
@@ -444,11 +444,11 @@ public class OrganizationWaiverServiceTests : IDisposable
         var today = DateTime.UtcNow.Date;
 
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater"), player.Id);
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Test User"), player.Id);
 
         var acceptance = await _context.WaiverAcceptances
             .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
-        acceptance.ParticipantName.Should().Be("Jane Skater");
+        acceptance.ParticipantName.Should().Be("Test User");
         acceptance.ParticipantDate.Should().Be(today);
         acceptance.ParticipantDate!.Value.Kind.Should().Be(DateTimeKind.Utc);
         acceptance.MinorParticipantName.Should().BeNull();
@@ -526,7 +526,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         await _sut.AcceptWaiverAsync(
             org.Id,
             new AcceptWaiverRequest(
-                waiver!.Id, "  Jane Skater  ",
+                waiver!.Id, "  Test User  ",
                 MinorParticipantName: " Minor Player ",
                 MinorDateOfBirth: today.AddYears(-12),
                 GuardianName: " Parent Guardian ",
@@ -535,7 +535,7 @@ public class OrganizationWaiverServiceTests : IDisposable
 
         var acceptance = await _context.WaiverAcceptances
             .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
-        acceptance.ParticipantName.Should().Be("Jane Skater");
+        acceptance.ParticipantName.Should().Be("Test User");
         acceptance.MinorParticipantName.Should().Be("Minor Player");
         acceptance.GuardianName.Should().Be("Parent Guardian");
         acceptance.GuardianSignature.Should().Be("Parent Guardian");
@@ -555,7 +555,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
         var today = DateTime.UtcNow.Date;
         var request = new AcceptWaiverRequest(
-            waiver!.Id, "Jane Skater",
+            waiver!.Id, "Test User",
             MinorParticipantName: filledField == "minorName" ? "Minor Player" : null,
             MinorDateOfBirth: filledField == "minorDob" ? today.AddYears(-12) : null,
             GuardianName: filledField == "guardianName" ? "Parent Guardian" : null,
@@ -580,7 +580,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         await _sut.AcceptWaiverAsync(
             org.Id,
             new AcceptWaiverRequest(
-                waiver!.Id, "Jane Skater",
+                waiver!.Id, "Test User",
                 MinorParticipantName: "   ",
                 GuardianName: " "),
             player.Id);
@@ -621,7 +621,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
 
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, "Original Name"), player.Id);
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Test User"), player.Id);
         // Re-accept the same version with different signature details
         await _sut.AcceptWaiverAsync(
             org.Id, MinorAcceptRequest(waiver.Id), player.Id);
@@ -631,7 +631,7 @@ public class OrganizationWaiverServiceTests : IDisposable
             .Where(a => a.WaiverId == waiver.Id && a.UserId == player.Id)
             .ToListAsync();
         acceptances.Should().HaveCount(1);
-        acceptances[0].ParticipantName.Should().Be("Original Name");
+        acceptances[0].ParticipantName.Should().Be("Test User");
         acceptances[0].ParticipantDate.Should().Be(DateTime.UtcNow.Date);
         acceptances[0].MinorParticipantName.Should().BeNull();
         acceptances[0].GuardianSignature.Should().BeNull();
@@ -645,16 +645,66 @@ public class OrganizationWaiverServiceTests : IDisposable
         var org = await CreateTestOrganization(admin.Id);
         var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(v1!.Id, "Old Name"), player.Id);
+            org.Id, new AcceptWaiverRequest(v1!.Id, "Test User"), player.Id);
 
         var v2 = await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(v2!.Id, "New Name"), player.Id);
+            org.Id, MinorAcceptRequest(v2!.Id), player.Id);
 
+        // Each accepted version keeps its own signature row
         var oldRow = await _context.WaiverAcceptances.SingleAsync(a => a.WaiverId == v1.Id && a.UserId == player.Id);
         var newRow = await _context.WaiverAcceptances.SingleAsync(a => a.WaiverId == v2.Id && a.UserId == player.Id);
-        oldRow.ParticipantName.Should().Be("Old Name");
-        newRow.ParticipantName.Should().Be("New Name");
+        oldRow.MinorParticipantName.Should().BeNull();
+        newRow.MinorParticipantName.Should().Be("Minor Player");
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_ParticipantNameNotMatchingProfile_Throws()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com"); // profile name: Test User
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Someone Else"), player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*must match the name on your profile: Test User*");
+        (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("test user")]           // case-insensitive
+    [InlineData("TEST USER")]
+    [InlineData("Test   User")]         // internal whitespace normalized
+    [InlineData("  Test User  ")]       // trimmed
+    public async Task AcceptWaiverAsync_ParticipantNameMatchingLoosely_Accepts(string enteredName)
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        await _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, enteredName), player.Id);
+
+        (await _context.WaiverAcceptances.CountAsync()).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AcceptWaiverAsync_InitialsInsteadOfFullName_Throws()
+    {
+        var admin = await CreateTestUser();
+        var player = await CreateTestUser("player@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
+
+        var act = () => _sut.AcceptWaiverAsync(
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "T. User"), player.Id);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*must match the name on your profile*");
     }
 
     [Fact]
@@ -673,7 +723,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         await _sut.AcceptWaiverAsync(
             org.Id,
             new AcceptWaiverRequest(
-                waiver!.Id, "Jane Skater",
+                waiver!.Id, "Test User",
                 MinorParticipantName: "Minor Player",
                 MinorDateOfBirth: unspecifiedDob,
                 GuardianName: "Parent Guardian",

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
@@ -744,6 +744,64 @@ public class OrganizationWaiverServiceTests : IDisposable
     #region Pending Waivers Tests
 
     [Fact]
+    public async Task GetPendingWaiversAsync_SubscriberWithoutRegistrations_Listed()
+    {
+        // Every org MEMBER must be current on the waiver, registrations or not
+        var admin = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(admin.Id, "Waiver Org");
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        _context.OrganizationSubscriptions.Add(new OrganizationSubscription
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = org.Id,
+            UserId = member.Id,
+            SubscribedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+
+        var pending = await _sut.GetPendingWaiversAsync(member.Id);
+
+        pending.Should().HaveCount(1);
+        pending[0].OrganizationId.Should().Be(org.Id);
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_SubscriberWhoAccepted_NotListed()
+    {
+        var admin = await CreateTestUser();
+        var member = await CreateTestUser("member@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        var waiver = await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+        _context.OrganizationSubscriptions.Add(new OrganizationSubscription
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = org.Id,
+            UserId = member.Id,
+            SubscribedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+        await _sut.AcceptWaiverAsync(org.Id, ValidAcceptRequest(waiver!.Id), member.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(member.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetPendingWaiversAsync_NonMemberWithoutRegistrations_NotListed()
+    {
+        var admin = await CreateTestUser();
+        var outsider = await CreateTestUser("outsider@example.com");
+        var org = await CreateTestOrganization(admin.Id);
+        await _sut.SetWaiverAsync(org.Id, "waiver text", admin.Id);
+
+        var pending = await _sut.GetPendingWaiversAsync(outsider.Id);
+
+        pending.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task GetPendingWaiversAsync_ListsOrgWithUnacceptedWaiverOnUpcomingEvent()
     {
         var admin = await CreateTestUser();

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationWaiverServiceTests.cs
@@ -136,7 +136,7 @@ public class OrganizationWaiverServiceTests : IDisposable
     /// </summary>
     private static AcceptWaiverRequest ValidAcceptRequest(Guid waiverId, string participantName = "Test Participant")
     {
-        return new AcceptWaiverRequest(waiverId, participantName, DateTime.UtcNow.Date);
+        return new AcceptWaiverRequest(waiverId, participantName);
     }
 
     /// <summary>
@@ -147,12 +147,10 @@ public class OrganizationWaiverServiceTests : IDisposable
         return new AcceptWaiverRequest(
             waiverId,
             "Guardian As Participant",
-            DateTime.UtcNow.Date,
             MinorParticipantName: "Minor Player",
             MinorDateOfBirth: DateTime.UtcNow.Date.AddYears(-12),
             GuardianName: "Parent Guardian",
-            GuardianSignature: "Parent Guardian",
-            GuardianDate: DateTime.UtcNow.Date);
+            GuardianSignature: "Parent Guardian");
     }
 
     #endregion
@@ -446,7 +444,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var today = DateTime.UtcNow.Date;
 
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater", today), player.Id);
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater"), player.Id);
 
         var acceptance = await _context.WaiverAcceptances
             .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
@@ -474,12 +472,12 @@ public class OrganizationWaiverServiceTests : IDisposable
         var acceptance = await _context.WaiverAcceptances
             .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
         acceptance.ParticipantName.Should().Be(request.ParticipantName);
-        acceptance.ParticipantDate.Should().Be(request.ParticipantDate);
+        acceptance.ParticipantDate.Should().Be(DateTime.UtcNow.Date); // server-stamped
         acceptance.MinorParticipantName.Should().Be(request.MinorParticipantName);
         acceptance.MinorDateOfBirth.Should().Be(request.MinorDateOfBirth);
         acceptance.GuardianName.Should().Be(request.GuardianName);
         acceptance.GuardianSignature.Should().Be(request.GuardianSignature);
-        acceptance.GuardianDate.Should().Be(request.GuardianDate);
+        acceptance.GuardianDate.Should().Be(DateTime.UtcNow.Date); // server-stamped
     }
 
     [Theory]
@@ -494,26 +492,10 @@ public class OrganizationWaiverServiceTests : IDisposable
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
 
         var act = () => _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, participantName, DateTime.UtcNow.Date), player.Id);
+            org.Id, new AcceptWaiverRequest(waiver!.Id, participantName), player.Id);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Printed name is required.");
-        (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
-    }
-
-    [Fact]
-    public async Task AcceptWaiverAsync_MissingParticipantDate_Throws()
-    {
-        var admin = await CreateTestUser();
-        var player = await CreateTestUser("player@example.com");
-        var org = await CreateTestOrganization(admin.Id);
-        var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
-
-        var act = () => _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater", null), player.Id);
-
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("Date is required.");
         (await _context.WaiverAcceptances.CountAsync()).Should().Be(0);
     }
 
@@ -526,7 +508,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
 
         var act = () => _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, new string('x', 201), DateTime.UtcNow.Date), player.Id);
+            org.Id, new AcceptWaiverRequest(waiver!.Id, new string('x', 201)), player.Id);
 
         await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("*200 characters or fewer*");
@@ -544,12 +526,11 @@ public class OrganizationWaiverServiceTests : IDisposable
         await _sut.AcceptWaiverAsync(
             org.Id,
             new AcceptWaiverRequest(
-                waiver!.Id, "  Jane Skater  ", today,
+                waiver!.Id, "  Jane Skater  ",
                 MinorParticipantName: " Minor Player ",
                 MinorDateOfBirth: today.AddYears(-12),
                 GuardianName: " Parent Guardian ",
-                GuardianSignature: " Parent Guardian ",
-                GuardianDate: today),
+                GuardianSignature: " Parent Guardian "),
             player.Id);
 
         var acceptance = await _context.WaiverAcceptances
@@ -566,7 +547,6 @@ public class OrganizationWaiverServiceTests : IDisposable
     [InlineData("minorDob")]
     [InlineData("guardianName")]
     [InlineData("guardianSignature")]
-    [InlineData("guardianDate")]
     public async Task AcceptWaiverAsync_PartialMinorSection_Throws(string filledField)
     {
         var admin = await CreateTestUser();
@@ -575,12 +555,11 @@ public class OrganizationWaiverServiceTests : IDisposable
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
         var today = DateTime.UtcNow.Date;
         var request = new AcceptWaiverRequest(
-            waiver!.Id, "Jane Skater", today,
+            waiver!.Id, "Jane Skater",
             MinorParticipantName: filledField == "minorName" ? "Minor Player" : null,
             MinorDateOfBirth: filledField == "minorDob" ? today.AddYears(-12) : null,
             GuardianName: filledField == "guardianName" ? "Parent Guardian" : null,
-            GuardianSignature: filledField == "guardianSignature" ? "Parent Guardian" : null,
-            GuardianDate: filledField == "guardianDate" ? today : null);
+            GuardianSignature: filledField == "guardianSignature" ? "Parent Guardian" : null);
 
         var act = () => _sut.AcceptWaiverAsync(org.Id, request, player.Id);
 
@@ -601,7 +580,7 @@ public class OrganizationWaiverServiceTests : IDisposable
         await _sut.AcceptWaiverAsync(
             org.Id,
             new AcceptWaiverRequest(
-                waiver!.Id, "Jane Skater", DateTime.UtcNow.Date,
+                waiver!.Id, "Jane Skater",
                 MinorParticipantName: "   ",
                 GuardianName: " "),
             player.Id);
@@ -640,10 +619,9 @@ public class OrganizationWaiverServiceTests : IDisposable
         var player = await CreateTestUser("player@example.com");
         var org = await CreateTestOrganization(admin.Id);
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
-        var firstDate = DateTime.UtcNow.Date.AddDays(-1);
 
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, "Original Name", firstDate), player.Id);
+            org.Id, new AcceptWaiverRequest(waiver!.Id, "Original Name"), player.Id);
         // Re-accept the same version with different signature details
         await _sut.AcceptWaiverAsync(
             org.Id, MinorAcceptRequest(waiver.Id), player.Id);
@@ -654,7 +632,7 @@ public class OrganizationWaiverServiceTests : IDisposable
             .ToListAsync();
         acceptances.Should().HaveCount(1);
         acceptances[0].ParticipantName.Should().Be("Original Name");
-        acceptances[0].ParticipantDate.Should().Be(firstDate);
+        acceptances[0].ParticipantDate.Should().Be(DateTime.UtcNow.Date);
         acceptances[0].MinorParticipantName.Should().BeNull();
         acceptances[0].GuardianSignature.Should().BeNull();
     }
@@ -667,11 +645,11 @@ public class OrganizationWaiverServiceTests : IDisposable
         var org = await CreateTestOrganization(admin.Id);
         var v1 = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(v1!.Id, "Old Name", DateTime.UtcNow.Date.AddDays(-30)), player.Id);
+            org.Id, new AcceptWaiverRequest(v1!.Id, "Old Name"), player.Id);
 
         var v2 = await _sut.SetWaiverAsync(org.Id, "v2", admin.Id);
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(v2!.Id, "New Name", DateTime.UtcNow.Date), player.Id);
+            org.Id, new AcceptWaiverRequest(v2!.Id, "New Name"), player.Id);
 
         var oldRow = await _context.WaiverAcceptances.SingleAsync(a => a.WaiverId == v1.Id && a.UserId == player.Id);
         var newRow = await _context.WaiverAcceptances.SingleAsync(a => a.WaiverId == v2.Id && a.UserId == player.Id);
@@ -686,16 +664,27 @@ public class OrganizationWaiverServiceTests : IDisposable
         var player = await CreateTestUser("player@example.com");
         var org = await CreateTestOrganization(admin.Id);
         var waiver = await _sut.SetWaiverAsync(org.Id, "v1", admin.Id);
-        // JSON date-only values ("2026-07-21") bind with Kind=Unspecified and may
-        // carry a time component from other clients - both must be normalized
-        var unspecified = DateTime.SpecifyKind(DateTime.UtcNow.Date.AddHours(14), DateTimeKind.Unspecified);
+        // JSON date-only values ("2014-03-05") bind with Kind=Unspecified and may
+        // carry a time component from other clients - both must be normalized.
+        // (Signature dates are server-stamped; only the DOB comes from the client.)
+        var unspecifiedDob = DateTime.SpecifyKind(
+            DateTime.UtcNow.Date.AddYears(-12).AddHours(14), DateTimeKind.Unspecified);
 
         await _sut.AcceptWaiverAsync(
-            org.Id, new AcceptWaiverRequest(waiver!.Id, "Jane Skater", unspecified), player.Id);
+            org.Id,
+            new AcceptWaiverRequest(
+                waiver!.Id, "Jane Skater",
+                MinorParticipantName: "Minor Player",
+                MinorDateOfBirth: unspecifiedDob,
+                GuardianName: "Parent Guardian",
+                GuardianSignature: "Parent Guardian"),
+            player.Id);
 
         var acceptance = await _context.WaiverAcceptances
             .SingleAsync(a => a.WaiverId == waiver.Id && a.UserId == player.Id);
-        acceptance.ParticipantDate.Should().Be(unspecified.Date);
+        acceptance.MinorDateOfBirth.Should().Be(unspecifiedDob.Date);
+        acceptance.MinorDateOfBirth!.Value.Kind.Should().Be(DateTimeKind.Utc);
+        acceptance.MinorDateOfBirth.Value.TimeOfDay.Should().Be(TimeSpan.Zero);
         acceptance.ParticipantDate!.Value.Kind.Should().Be(DateTimeKind.Utc);
         acceptance.ParticipantDate.Value.TimeOfDay.Should().Be(TimeSpan.Zero);
     }

--- a/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
@@ -306,8 +306,11 @@ public class OrganizationsController : ControllerBase
     }
 
     /// <summary>
-    /// Accept a SPECIFIC waiver version. 400 when the id is not the org's current
-    /// active version (stale-version protection). Idempotent when already accepted.
+    /// Accept a SPECIFIC waiver version, recording the signature fields on the
+    /// acceptance row. 400 when the id is not the org's current active version
+    /// (stale-version protection), when the participant name/date is missing,
+    /// or when the Parent/Guardian section is partially filled. Idempotent when
+    /// already accepted (the original signature fields are preserved).
     /// </summary>
     [HttpPost("{id:guid}/waiver/accept")]
     [Authorize]
@@ -317,7 +320,7 @@ public class OrganizationsController : ControllerBase
 
         try
         {
-            await _waiverService.AcceptWaiverAsync(id, request.WaiverId, userId);
+            await _waiverService.AcceptWaiverAsync(id, request, userId);
             return Ok(new { message = "Waiver accepted" });
         }
         catch (InvalidOperationException ex)

--- a/apps/api/BHMHockey.Api/Data/AppDbContext.cs
+++ b/apps/api/BHMHockey.Api/Data/AppDbContext.cs
@@ -187,6 +187,12 @@ public class AppDbContext : DbContext
         {
             entity.HasKey(e => e.Id);
 
+            // Signature fields (nullable - rows predating signatures keep nulls)
+            entity.Property(e => e.ParticipantName).HasMaxLength(200);
+            entity.Property(e => e.MinorParticipantName).HasMaxLength(200);
+            entity.Property(e => e.GuardianName).HasMaxLength(200);
+            entity.Property(e => e.GuardianSignature).HasMaxLength(200);
+
             // A user accepts each waiver version at most once
             entity.HasIndex(e => new { e.UserId, e.WaiverId }).IsUnique();
 

--- a/apps/api/BHMHockey.Api/Migrations/20260721223911_AddWaiverSignatureFields.Designer.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260721223911_AddWaiverSignatureFields.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BHMHockey.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace BHMHockey.Api.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721223911_AddWaiverSignatureFields")]
+    partial class AddWaiverSignatureFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/BHMHockey.Api/Migrations/20260721223911_AddWaiverSignatureFields.cs
+++ b/apps/api/BHMHockey.Api/Migrations/20260721223911_AddWaiverSignatureFields.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BHMHockey.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWaiverSignatureFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "GuardianDate",
+                table: "WaiverAcceptances",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GuardianName",
+                table: "WaiverAcceptances",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "GuardianSignature",
+                table: "WaiverAcceptances",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "MinorDateOfBirth",
+                table: "WaiverAcceptances",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MinorParticipantName",
+                table: "WaiverAcceptances",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "ParticipantDate",
+                table: "WaiverAcceptances",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ParticipantName",
+                table: "WaiverAcceptances",
+                type: "character varying(200)",
+                maxLength: 200,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GuardianDate",
+                table: "WaiverAcceptances");
+
+            migrationBuilder.DropColumn(
+                name: "GuardianName",
+                table: "WaiverAcceptances");
+
+            migrationBuilder.DropColumn(
+                name: "GuardianSignature",
+                table: "WaiverAcceptances");
+
+            migrationBuilder.DropColumn(
+                name: "MinorDateOfBirth",
+                table: "WaiverAcceptances");
+
+            migrationBuilder.DropColumn(
+                name: "MinorParticipantName",
+                table: "WaiverAcceptances");
+
+            migrationBuilder.DropColumn(
+                name: "ParticipantDate",
+                table: "WaiverAcceptances");
+
+            migrationBuilder.DropColumn(
+                name: "ParticipantName",
+                table: "WaiverAcceptances");
+        }
+    }
+}

--- a/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
@@ -25,15 +25,15 @@ public record SetOrganizationWaiverResponse(
 // blank). The Parent/Guardian section is all-or-nothing: either every minor
 // field is provided (participant under 19) or all are omitted (400 when
 // partially filled). Dates are calendar dates (client sends YYYY-MM-DD).
+// Signature dates (adult and guardian) are stamped server-side at acceptance
+// time and are intentionally NOT accepted from the client
 public record AcceptWaiverRequest(
     Guid WaiverId,
     string? ParticipantName,
-    DateTime? ParticipantDate,
     string? MinorParticipantName = null,
     DateTime? MinorDateOfBirth = null,
     string? GuardianName = null,
-    string? GuardianSignature = null,
-    DateTime? GuardianDate = null
+    string? GuardianSignature = null
 );
 
 // Blocking-gate entry: an org where the current user holds an upcoming

--- a/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
@@ -19,9 +19,21 @@ public record SetOrganizationWaiverResponse(
     OrganizationWaiverDto? Waiver
 );
 
-// Accept a SPECIFIC waiver version (stale ids are rejected with 400)
+// Accept a SPECIFIC waiver version (stale ids are rejected with 400).
+// Signature fields are recorded once on the acceptance row (immutable audit
+// data). ParticipantName/ParticipantDate are required (400 when missing or
+// blank). The Parent/Guardian section is all-or-nothing: either every minor
+// field is provided (participant under 19) or all are omitted (400 when
+// partially filled). Dates are calendar dates (client sends YYYY-MM-DD).
 public record AcceptWaiverRequest(
-    Guid WaiverId
+    Guid WaiverId,
+    string? ParticipantName,
+    DateTime? ParticipantDate,
+    string? MinorParticipantName = null,
+    DateTime? MinorDateOfBirth = null,
+    string? GuardianName = null,
+    string? GuardianSignature = null,
+    DateTime? GuardianDate = null
 );
 
 // Blocking-gate entry: an org where the current user holds an upcoming

--- a/apps/api/BHMHockey.Api/Models/Entities/WaiverAcceptance.cs
+++ b/apps/api/BHMHockey.Api/Models/Entities/WaiverAcceptance.cs
@@ -13,4 +13,20 @@ public class WaiverAcceptance
     public Guid WaiverId { get; set; }
     public OrganizationWaiver Waiver { get; set; } = null!;
     public DateTime AcceptedAt { get; set; } = DateTime.UtcNow;
+
+    // Signature fields captured at acceptance time. Immutable audit data:
+    // written once when the acceptance is recorded and never updated
+    // (re-accepting the same version keeps the original values). Null on
+    // rows recorded before signatures were introduced. Dates are calendar
+    // dates stored at UTC midnight.
+    public string? ParticipantName { get; set; }
+    public DateTime? ParticipantDate { get; set; }
+
+    // Parent/Guardian section - all-or-nothing: either every field below is
+    // set (participant under 19) or all are null (adult-only acceptance)
+    public string? MinorParticipantName { get; set; }
+    public DateTime? MinorDateOfBirth { get; set; }
+    public string? GuardianName { get; set; }
+    public string? GuardianSignature { get; set; }
+    public DateTime? GuardianDate { get; set; }
 }

--- a/apps/api/BHMHockey.Api/Services/IOrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/IOrganizationWaiverService.cs
@@ -20,11 +20,14 @@ public interface IOrganizationWaiverService
     Task<OrganizationWaiverDto?> SetWaiverAsync(Guid organizationId, string? text, Guid userId);
 
     /// <summary>
-    /// Record that the user accepted a SPECIFIC waiver version. Rejects
-    /// (InvalidOperationException) when the id is not the org's current active
-    /// version (stale-version protection). Idempotent when already accepted.
+    /// Record that the user accepted a SPECIFIC waiver version, including the
+    /// signature fields captured at acceptance. Rejects (InvalidOperationException)
+    /// when the id is not the org's current active version (stale-version
+    /// protection), when the participant name/date is missing, or when the
+    /// Parent/Guardian section is partially filled (all-or-nothing). Idempotent
+    /// when already accepted - the original row's signature fields are preserved.
     /// </summary>
-    Task AcceptWaiverAsync(Guid organizationId, Guid waiverId, Guid userId);
+    Task AcceptWaiverAsync(Guid organizationId, AcceptWaiverRequest request, Guid userId);
 
     /// <summary>
     /// Orgs where the user holds an active (Registered/Waitlisted) registration on

--- a/apps/api/BHMHockey.Api/Services/OrganizationService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationService.cs
@@ -402,16 +402,20 @@ public class OrganizationService : IOrganizationService
             .GroupBy(ub => ub.UserId)
             .ToDictionary(g => g.Key, g => g.Count());
 
-        // Waiver status per member - only meaningful when an active waiver exists
-        // (flags stay null otherwise so clients hide the waiver UI entirely)
-        var activeWaiverId = await _waiverService.GetActiveWaiverIdAsync(organizationId);
+        // Waiver status per member - ADMIN-ONLY (like member emails above), and
+        // only meaningful when an active waiver exists. Null flags keep the
+        // client waiver UI hidden entirely.
         HashSet<Guid>? acceptedUserIds = null;
-        if (activeWaiverId.HasValue)
+        if (isAdmin)
         {
-            acceptedUserIds = (await _context.WaiverAcceptances
-                .Where(a => a.WaiverId == activeWaiverId.Value && memberUserIds.Contains(a.UserId))
-                .Select(a => a.UserId)
-                .ToListAsync()).ToHashSet();
+            var activeWaiverId = await _waiverService.GetActiveWaiverIdAsync(organizationId);
+            if (activeWaiverId.HasValue)
+            {
+                acceptedUserIds = (await _context.WaiverAcceptances
+                    .Where(a => a.WaiverId == activeWaiverId.Value && memberUserIds.Contains(a.UserId))
+                    .Select(a => a.UserId)
+                    .ToListAsync()).ToHashSet();
+            }
         }
 
         // Build member DTOs

--- a/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
@@ -286,16 +286,24 @@ public class OrganizationWaiverService : IOrganizationWaiverService
     {
         var now = DateTime.UtcNow;
 
-        // Orgs where the user holds an active registration on an upcoming, non-cancelled event
-        var orgIds = await _context.EventRegistrations
+        // Every org the user is a MEMBER of must be current on the waiver...
+        var subscribedOrgIds = await _context.OrganizationSubscriptions
+            .Where(s => s.UserId == userId)
+            .Select(s => s.OrganizationId)
+            .ToListAsync();
+
+        // ...plus orgs where a non-member holds an active registration on an
+        // upcoming, non-cancelled event (e.g. manually added by an organizer)
+        var registeredOrgIds = await _context.EventRegistrations
             .Where(r => r.UserId == userId
                 && (r.Status == "Registered" || r.Status == "Waitlisted")
                 && r.Event.OrganizationId != null
                 && r.Event.EventDate > now
                 && r.Event.Status != "Cancelled")
             .Select(r => r.Event.OrganizationId!.Value)
-            .Distinct()
             .ToListAsync();
+
+        var orgIds = subscribedOrgIds.Union(registeredOrgIds).ToList();
 
         if (orgIds.Count == 0)
         {

--- a/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
@@ -137,6 +137,21 @@ public class OrganizationWaiverService : IOrganizationWaiverService
 
         var signature = ValidateSignatureFields(organizationId, request);
 
+        // The adult printed name is the account holder's attestation - it must
+        // match their profile name (guardian/minor names are other people and
+        // are not checked)
+        var user = await _context.Users.FindAsync(userId)
+            ?? throw new InvalidOperationException("User not found");
+        var profileName = $"{user.FirstName} {user.LastName}";
+        if (!NamesMatch(signature.ParticipantName, profileName))
+        {
+            _logger.LogWarning(
+                "Waiver acceptance rejected for user {UserId}: printed name does not match profile name",
+                userId);
+            throw new InvalidOperationException(
+                $"Printed name must match the name on your profile: {profileName}");
+        }
+
         var alreadyAccepted = await _context.WaiverAcceptances
             .AnyAsync(a => a.WaiverId == request.WaiverId && a.UserId == userId);
         if (alreadyAccepted)
@@ -163,6 +178,18 @@ public class OrganizationWaiverService : IOrganizationWaiverService
 
     // Max stored length for each signature text field (also enforced by EF config)
     private const int SignatureFieldMaxLength = 200;
+
+    /// <summary>
+    /// Case-insensitive, whitespace-normalized name comparison: "jane  skater"
+    /// matches "Jane Skater"; initials or different names do not. Mirrored
+    /// client-side in apps/mobile/utils/waiverSignature.ts - keep in sync.
+    /// </summary>
+    private static bool NamesMatch(string entered, string profileName)
+    {
+        static string Normalize(string value) => string.Join(' ',
+            value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries)).ToLowerInvariant();
+        return Normalize(entered) == Normalize(profileName);
+    }
 
     private record ValidatedSignature(
         string ParticipantName,

--- a/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
@@ -124,30 +124,136 @@ public class OrganizationWaiverService : IOrganizationWaiverService
         return trimmed.Length == 0 ? null : MapToDto(waiver);
     }
 
-    public async Task AcceptWaiverAsync(Guid organizationId, Guid waiverId, Guid userId)
+    public async Task AcceptWaiverAsync(Guid organizationId, AcceptWaiverRequest request, Guid userId)
     {
         var active = await GetActiveWaiverAsync(organizationId);
-        if (active == null || active.Id != waiverId)
+        if (active == null || active.Id != request.WaiverId)
         {
             _logger.LogWarning(
                 "Waiver acceptance rejected for organization {OrganizationId}: waiver {WaiverId} is not the current active version",
-                organizationId, waiverId);
+                organizationId, request.WaiverId);
             throw new InvalidOperationException("This waiver version is no longer current. Please review and accept the latest waiver.");
         }
 
+        var signature = ValidateSignatureFields(organizationId, request);
+
         var alreadyAccepted = await _context.WaiverAcceptances
-            .AnyAsync(a => a.WaiverId == waiverId && a.UserId == userId);
+            .AnyAsync(a => a.WaiverId == request.WaiverId && a.UserId == userId);
         if (alreadyAccepted)
         {
-            return; // Idempotent
+            // Idempotent - the original acceptance row (including its signature
+            // fields) is an immutable audit record and is never overwritten
+            return;
         }
 
         _context.WaiverAcceptances.Add(new WaiverAcceptance
         {
             UserId = userId,
-            WaiverId = waiverId
+            WaiverId = request.WaiverId,
+            ParticipantName = signature.ParticipantName,
+            ParticipantDate = signature.ParticipantDate,
+            MinorParticipantName = signature.MinorParticipantName,
+            MinorDateOfBirth = signature.MinorDateOfBirth,
+            GuardianName = signature.GuardianName,
+            GuardianSignature = signature.GuardianSignature,
+            GuardianDate = signature.GuardianDate
         });
         await _context.SaveChangesAsync();
+    }
+
+    // Max stored length for each signature text field (also enforced by EF config)
+    private const int SignatureFieldMaxLength = 200;
+
+    private record ValidatedSignature(
+        string ParticipantName,
+        DateTime ParticipantDate,
+        string? MinorParticipantName,
+        DateTime? MinorDateOfBirth,
+        string? GuardianName,
+        string? GuardianSignature,
+        DateTime? GuardianDate
+    );
+
+    /// <summary>
+    /// Server-side mirror of the acceptance form rules: participant name/date
+    /// required; Parent/Guardian section all-or-nothing with the minor's date
+    /// of birth in the past. Strings are trimmed and length-capped; dates are
+    /// normalized to calendar dates at UTC midnight.
+    /// </summary>
+    private ValidatedSignature ValidateSignatureFields(Guid organizationId, AcceptWaiverRequest request)
+    {
+        void Reject(string message)
+        {
+            _logger.LogWarning(
+                "Waiver acceptance rejected for organization {OrganizationId}: {Message}",
+                organizationId, message);
+            throw new InvalidOperationException(message);
+        }
+
+        string? Clean(string? value, string label)
+        {
+            var trimmed = value?.Trim();
+            if (string.IsNullOrEmpty(trimmed))
+            {
+                return null;
+            }
+            if (trimmed.Length > SignatureFieldMaxLength)
+            {
+                Reject($"{label} must be {SignatureFieldMaxLength} characters or fewer.");
+            }
+            return trimmed;
+        }
+
+        var participantName = Clean(request.ParticipantName, "Printed name");
+        if (participantName == null)
+        {
+            Reject("Printed name is required.");
+        }
+        if (request.ParticipantDate == null)
+        {
+            Reject("Date is required.");
+        }
+
+        var minorName = Clean(request.MinorParticipantName, "Minor participant's printed name");
+        var guardianName = Clean(request.GuardianName, "Parent/guardian printed name");
+        var guardianSignature = Clean(request.GuardianSignature, "Parent/guardian signature");
+
+        var anyMinorField = minorName != null || request.MinorDateOfBirth != null
+            || guardianName != null || guardianSignature != null || request.GuardianDate != null;
+
+        if (anyMinorField)
+        {
+            var allMinorFields = minorName != null && request.MinorDateOfBirth != null
+                && guardianName != null && guardianSignature != null && request.GuardianDate != null;
+            if (!allMinorFields)
+            {
+                Reject("The Parent/Guardian section is all-or-nothing: provide the minor's name, date of birth, parent/guardian name, signature, and date - or leave the whole section empty.");
+            }
+            if (AsUtcDate(request.MinorDateOfBirth!.Value) >= DateTime.UtcNow.Date)
+            {
+                Reject("Minor's date of birth must be in the past.");
+            }
+        }
+
+        return new ValidatedSignature(
+            participantName!,
+            AsUtcDate(request.ParticipantDate!.Value),
+            anyMinorField ? minorName : null,
+            anyMinorField ? AsUtcDate(request.MinorDateOfBirth!.Value) : null,
+            anyMinorField ? guardianName : null,
+            anyMinorField ? guardianSignature : null,
+            anyMinorField ? AsUtcDate(request.GuardianDate!.Value) : null
+        );
+    }
+
+    /// <summary>
+    /// Signature dates are calendar dates (the client sends YYYY-MM-DD, which
+    /// binds with Kind=Unspecified). Store them at UTC midnight per the repo's
+    /// all-dates-are-UTC convention (Npgsql rejects non-UTC kinds).
+    /// </summary>
+    private static DateTime AsUtcDate(DateTime value)
+    {
+        return DateTime.SpecifyKind(value.Date, DateTimeKind.Utc);
     }
 
     public async Task<List<PendingWaiverDto>> GetPendingWaiversAsync(Guid userId)

--- a/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationWaiverService.cs
@@ -209,25 +209,21 @@ public class OrganizationWaiverService : IOrganizationWaiverService
         {
             Reject("Printed name is required.");
         }
-        if (request.ParticipantDate == null)
-        {
-            Reject("Date is required.");
-        }
 
         var minorName = Clean(request.MinorParticipantName, "Minor participant's printed name");
         var guardianName = Clean(request.GuardianName, "Parent/guardian printed name");
         var guardianSignature = Clean(request.GuardianSignature, "Parent/guardian signature");
 
         var anyMinorField = minorName != null || request.MinorDateOfBirth != null
-            || guardianName != null || guardianSignature != null || request.GuardianDate != null;
+            || guardianName != null || guardianSignature != null;
 
         if (anyMinorField)
         {
             var allMinorFields = minorName != null && request.MinorDateOfBirth != null
-                && guardianName != null && guardianSignature != null && request.GuardianDate != null;
+                && guardianName != null && guardianSignature != null;
             if (!allMinorFields)
             {
-                Reject("The Parent/Guardian section is all-or-nothing: provide the minor's name, date of birth, parent/guardian name, signature, and date - or leave the whole section empty.");
+                Reject("The Parent/Guardian section is all-or-nothing: provide the minor's name, date of birth, parent/guardian name, and signature - or leave the whole section empty.");
             }
             if (AsUtcDate(request.MinorDateOfBirth!.Value) >= DateTime.UtcNow.Date)
             {
@@ -235,14 +231,17 @@ public class OrganizationWaiverService : IOrganizationWaiverService
             }
         }
 
+        // Signature dates are stamped by the server, never taken from the
+        // client - the recorded date is always the actual acceptance date
+        var signedOn = DateTime.UtcNow.Date;
         return new ValidatedSignature(
             participantName!,
-            AsUtcDate(request.ParticipantDate!.Value),
+            signedOn,
             anyMinorField ? minorName : null,
             anyMinorField ? AsUtcDate(request.MinorDateOfBirth!.Value) : null,
             anyMinorField ? guardianName : null,
             anyMinorField ? guardianSignature : null,
-            anyMinorField ? AsUtcDate(request.GuardianDate!.Value) : null
+            anyMinorField ? signedOn : null
         );
     }
 

--- a/apps/mobile/__tests__/stores/waiverStore.test.ts
+++ b/apps/mobile/__tests__/stores/waiverStore.test.ts
@@ -24,7 +24,6 @@ import type { PendingWaiver, WaiverSignatureDetails } from '@bhmhockey/shared';
 
 const mockSignature: WaiverSignatureDetails = {
   participantName: 'Jane Skater',
-  participantDate: '2026-07-21',
 };
 
 const createMockPendingWaiver = (overrides: Partial<PendingWaiver> = {}): PendingWaiver => ({
@@ -121,7 +120,6 @@ describe('waiverStore', () => {
         minorDateOfBirth: '2014-03-05',
         guardianName: 'Pat Guardian',
         guardianSignature: 'Pat Guardian',
-        guardianDate: '2026-07-21',
       };
 
       const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1', minorSignature);

--- a/apps/mobile/__tests__/stores/waiverStore.test.ts
+++ b/apps/mobile/__tests__/stores/waiverStore.test.ts
@@ -20,7 +20,12 @@ jest.mock('@bhmhockey/api-client', () => ({
 
 // Import after mocking
 import { useWaiverStore } from '../../stores/waiverStore';
-import type { PendingWaiver } from '@bhmhockey/shared';
+import type { PendingWaiver, WaiverSignatureDetails } from '@bhmhockey/shared';
+
+const mockSignature: WaiverSignatureDetails = {
+  participantName: 'Jane Skater',
+  participantDate: '2026-07-21',
+};
 
 const createMockPendingWaiver = (overrides: Partial<PendingWaiver> = {}): PendingWaiver => ({
   organizationId: 'org-1',
@@ -98,12 +103,31 @@ describe('waiverStore', () => {
       useWaiverStore.setState({ pendingWaivers: [org1, org2] });
       mockAcceptWaiver.mockResolvedValue(undefined);
 
-      const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1');
+      const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1', mockSignature);
 
       expect(result).toBe(true);
-      expect(mockAcceptWaiver).toHaveBeenCalledWith('org-1', 'waiver-1');
+      // Signature fields captured on the form are passed straight through
+      expect(mockAcceptWaiver).toHaveBeenCalledWith('org-1', 'waiver-1', mockSignature);
       // Queue advances to the next org
       expect(useWaiverStore.getState().pendingWaivers).toEqual([org2]);
+    });
+
+    it('passes the full Parent/Guardian section through to the API', async () => {
+      useWaiverStore.setState({ pendingWaivers: [createMockPendingWaiver()] });
+      mockAcceptWaiver.mockResolvedValue(undefined);
+      const minorSignature: WaiverSignatureDetails = {
+        ...mockSignature,
+        minorParticipantName: 'Minor Player',
+        minorDateOfBirth: '2014-03-05',
+        guardianName: 'Pat Guardian',
+        guardianSignature: 'Pat Guardian',
+        guardianDate: '2026-07-21',
+      };
+
+      const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1', minorSignature);
+
+      expect(result).toBe(true);
+      expect(mockAcceptWaiver).toHaveBeenCalledWith('org-1', 'waiver-1', minorSignature);
     });
 
     it('sets error, refreshes the queue, and returns false on failure', async () => {
@@ -115,7 +139,7 @@ describe('waiverStore', () => {
       })];
       mockGetPendingWaivers.mockResolvedValue(refreshed);
 
-      const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1');
+      const result = await useWaiverStore.getState().acceptWaiver('org-1', 'waiver-1', mockSignature);
 
       expect(result).toBe(false);
       expect(useWaiverStore.getState().error).toBe('This waiver version is no longer current.');

--- a/apps/mobile/__tests__/utils/waiverSignature.test.ts
+++ b/apps/mobile/__tests__/utils/waiverSignature.test.ts
@@ -1,0 +1,242 @@
+import {
+  emptyWaiverSignatureForm,
+  isPastDate,
+  parseDateInput,
+  todayMMDDYYYY,
+  toIsoDate,
+  validateWaiverSignature,
+  type WaiverSignatureFormValues,
+} from '../../utils/waiverSignature';
+
+// Fixed "now" so date-relative assertions are deterministic
+const NOW = new Date(2026, 6, 21); // July 21, 2026 (local)
+
+const validAdultForm = (): WaiverSignatureFormValues => ({
+  ...emptyWaiverSignatureForm(NOW),
+  participantName: 'Jane Skater',
+});
+
+const validMinorForm = (): WaiverSignatureFormValues => ({
+  ...validAdultForm(),
+  minorParticipantName: 'Minor Player',
+  minorDateOfBirth: '03/05/2014',
+  guardianName: 'Pat Guardian',
+  guardianSignature: 'Pat Guardian',
+});
+
+describe('todayMMDDYYYY', () => {
+  it('formats the local date as MM/DD/YYYY with zero padding', () => {
+    expect(todayMMDDYYYY(new Date(2026, 6, 21))).toBe('07/21/2026');
+    expect(todayMMDDYYYY(new Date(2026, 11, 5))).toBe('12/05/2026');
+  });
+});
+
+describe('parseDateInput', () => {
+  it('parses MM/DD/YYYY', () => {
+    expect(parseDateInput('07/21/2026')).toEqual({ year: 2026, month: 7, day: 21 });
+  });
+
+  it('accepts 1-digit month and day', () => {
+    expect(parseDateInput('7/4/2026')).toEqual({ year: 2026, month: 7, day: 4 });
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseDateInput(' 07/21/2026 ')).toEqual({ year: 2026, month: 7, day: 21 });
+  });
+
+  it.each([
+    ['empty', ''],
+    ['garbage', 'not a date'],
+    ['2-digit year', '07/21/26'],
+    ['ISO format', '2026-07-21'],
+    ['month 13', '13/01/2026'],
+    ['month 0', '0/10/2026'],
+    ['day rollover', '02/30/2026'],
+    ['day 32', '01/32/2026'],
+    ['missing year', '07/21'],
+  ])('rejects %s', (_label, value) => {
+    expect(parseDateInput(value)).toBeNull();
+  });
+
+  it('accepts Feb 29 only in leap years', () => {
+    expect(parseDateInput('02/29/2024')).toEqual({ year: 2024, month: 2, day: 29 });
+    expect(parseDateInput('02/29/2026')).toBeNull();
+  });
+});
+
+describe('toIsoDate', () => {
+  it('formats as YYYY-MM-DD with zero padding', () => {
+    expect(toIsoDate({ year: 2026, month: 7, day: 4 })).toBe('2026-07-04');
+  });
+});
+
+describe('isPastDate', () => {
+  it('is true for yesterday, false for today and tomorrow', () => {
+    expect(isPastDate({ year: 2026, month: 7, day: 20 }, NOW)).toBe(true);
+    expect(isPastDate({ year: 2026, month: 7, day: 21 }, NOW)).toBe(false);
+    expect(isPastDate({ year: 2026, month: 7, day: 22 }, NOW)).toBe(false);
+  });
+});
+
+describe('emptyWaiverSignatureForm', () => {
+  it('pre-fills both date fields with today and leaves everything else empty', () => {
+    const form = emptyWaiverSignatureForm(NOW);
+    expect(form.participantDate).toBe('07/21/2026');
+    expect(form.guardianDate).toBe('07/21/2026');
+    expect(form.participantName).toBe('');
+    expect(form.minorParticipantName).toBe('');
+    expect(form.minorDateOfBirth).toBe('');
+    expect(form.guardianName).toBe('');
+    expect(form.guardianSignature).toBe('');
+  });
+});
+
+describe('validateWaiverSignature', () => {
+  describe('adult participant', () => {
+    it('accepts a valid adult-only form and builds the payload without minor fields', () => {
+      const result = validateWaiverSignature(validAdultForm(), NOW);
+
+      expect(result.valid).toBe(true);
+      expect(result.errors).toEqual({});
+      expect(result.details).toEqual({
+        participantName: 'Jane Skater',
+        participantDate: '2026-07-21',
+      });
+    });
+
+    it('trims the participant name in the payload', () => {
+      const result = validateWaiverSignature(
+        { ...validAdultForm(), participantName: '  Jane Skater  ' },
+        NOW
+      );
+
+      expect(result.details?.participantName).toBe('Jane Skater');
+    });
+
+    it.each([
+      ['empty', ''],
+      ['whitespace-only', '   '],
+    ])('requires the printed name (%s)', (_label, participantName) => {
+      const result = validateWaiverSignature({ ...validAdultForm(), participantName }, NOW);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.participantName).toBe('Printed name is required');
+      expect(result.details).toBeNull();
+    });
+
+    it('rejects an invalid participant date', () => {
+      const result = validateWaiverSignature(
+        { ...validAdultForm(), participantDate: '13/45/20' },
+        NOW
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.participantDate).toBe('Enter a valid date (MM/DD/YYYY)');
+    });
+
+    it('rejects an emptied participant date', () => {
+      const result = validateWaiverSignature({ ...validAdultForm(), participantDate: '' }, NOW);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.participantDate).toBeDefined();
+    });
+  });
+
+  describe('Parent/Guardian section (all-or-nothing)', () => {
+    it('accepts a fully filled minor section and includes it in the payload', () => {
+      const result = validateWaiverSignature(validMinorForm(), NOW);
+
+      expect(result.valid).toBe(true);
+      expect(result.details).toEqual({
+        participantName: 'Jane Skater',
+        participantDate: '2026-07-21',
+        minorParticipantName: 'Minor Player',
+        minorDateOfBirth: '2014-03-05',
+        guardianName: 'Pat Guardian',
+        guardianSignature: 'Pat Guardian',
+        guardianDate: '2026-07-21',
+      });
+    });
+
+    it('treats an untouched section (only the pre-filled date) as empty', () => {
+      // guardianDate is pre-filled with today, so it must not by itself
+      // activate the all-or-nothing rule
+      const result = validateWaiverSignature(validAdultForm(), NOW);
+
+      expect(result.valid).toBe(true);
+      expect(result.details?.guardianDate).toBeUndefined();
+      expect(result.details?.minorParticipantName).toBeUndefined();
+    });
+
+    it.each([
+      ['minor name', { minorParticipantName: 'Minor Player' }],
+      ['minor date of birth', { minorDateOfBirth: '03/05/2014' }],
+      ['guardian name', { guardianName: 'Pat Guardian' }],
+      ['guardian signature', { guardianSignature: 'Pat Guardian' }],
+    ])('filling only the %s marks the other minor fields as required', (_label, partial) => {
+      const result = validateWaiverSignature({ ...validAdultForm(), ...partial }, NOW);
+
+      expect(result.valid).toBe(false);
+      expect(result.details).toBeNull();
+      // Every missing group field gets its own inline error
+      const groupKeys = [
+        'minorParticipantName',
+        'minorDateOfBirth',
+        'guardianName',
+        'guardianSignature',
+      ] as const;
+      for (const key of groupKeys) {
+        if (key in partial) {
+          expect(result.errors[key]).toBeUndefined();
+        } else {
+          expect(result.errors[key]).toBeDefined();
+        }
+      }
+    });
+
+    it('requires the guardian date when the section is started and the date was cleared', () => {
+      const result = validateWaiverSignature({ ...validMinorForm(), guardianDate: '' }, NOW);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.guardianDate).toBe('Date is required to complete this section');
+    });
+
+    it('rejects an invalid guardian date when the section is started', () => {
+      const result = validateWaiverSignature({ ...validMinorForm(), guardianDate: '02/30/2026' }, NOW);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.guardianDate).toBe('Enter a valid date (MM/DD/YYYY)');
+    });
+
+    it.each([
+      ['today', '07/21/2026'],
+      ['the future', '01/01/2030'],
+    ])("rejects a minor date of birth set to %s", (_label, minorDateOfBirth) => {
+      const result = validateWaiverSignature({ ...validMinorForm(), minorDateOfBirth }, NOW);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.minorDateOfBirth).toBe('Date of birth must be in the past');
+    });
+
+    it('rejects an unparseable minor date of birth', () => {
+      const result = validateWaiverSignature({ ...validMinorForm(), minorDateOfBirth: 'nope' }, NOW);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.minorDateOfBirth).toBe('Enter a valid date (MM/DD/YYYY)');
+    });
+
+    it('trims minor-section strings in the payload', () => {
+      const result = validateWaiverSignature(
+        {
+          ...validMinorForm(),
+          minorParticipantName: ' Minor Player ',
+          guardianSignature: '  Pat Guardian ',
+        },
+        NOW
+      );
+
+      expect(result.details?.minorParticipantName).toBe('Minor Player');
+      expect(result.details?.guardianSignature).toBe('Pat Guardian');
+    });
+  });
+});

--- a/apps/mobile/__tests__/utils/waiverSignature.test.ts
+++ b/apps/mobile/__tests__/utils/waiverSignature.test.ts
@@ -122,6 +122,49 @@ describe('validateWaiverSignature', () => {
       expect(result.errors.participantName).toBe('Printed name is required');
       expect(result.details).toBeNull();
     });
+
+    describe('profile name matching', () => {
+      it.each([
+        ['exact', 'Jane Skater'],
+        ['case-insensitive', 'jane skater'],
+        ['extra internal spaces', 'Jane   Skater'],
+        ['padded', '  Jane Skater  '],
+      ])('accepts a %s match against the profile name', (_label, participantName) => {
+        const result = validateWaiverSignature(
+          { ...validAdultForm(), participantName },
+          NOW,
+          'Jane Skater'
+        );
+
+        expect(result.valid).toBe(true);
+      });
+
+      it.each([
+        ['a different name', 'Someone Else'],
+        ['initials', 'J. Skater'],
+        ['first name only', 'Jane'],
+      ])('rejects %s with a must-match error', (_label, participantName) => {
+        const result = validateWaiverSignature(
+          { ...validAdultForm(), participantName },
+          NOW,
+          'Jane Skater'
+        );
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.participantName).toBe(
+          'Must match the name on your profile: Jane Skater'
+        );
+      });
+
+      it('skips the match check when no profile name is provided', () => {
+        const result = validateWaiverSignature(
+          { ...validAdultForm(), participantName: 'Anyone At All' },
+          NOW
+        );
+
+        expect(result.valid).toBe(true);
+      });
+    });
   });
 
   describe('Parent/Guardian section (all-or-nothing)', () => {

--- a/apps/mobile/__tests__/utils/waiverSignature.test.ts
+++ b/apps/mobile/__tests__/utils/waiverSignature.test.ts
@@ -12,7 +12,7 @@ import {
 const NOW = new Date(2026, 6, 21); // July 21, 2026 (local)
 
 const validAdultForm = (): WaiverSignatureFormValues => ({
-  ...emptyWaiverSignatureForm(NOW),
+  ...emptyWaiverSignatureForm(),
   participantName: 'Jane Skater',
 });
 
@@ -79,28 +79,27 @@ describe('isPastDate', () => {
 });
 
 describe('emptyWaiverSignatureForm', () => {
-  it('pre-fills both date fields with today and leaves everything else empty', () => {
-    const form = emptyWaiverSignatureForm(NOW);
-    expect(form.participantDate).toBe('07/21/2026');
-    expect(form.guardianDate).toBe('07/21/2026');
-    expect(form.participantName).toBe('');
-    expect(form.minorParticipantName).toBe('');
-    expect(form.minorDateOfBirth).toBe('');
-    expect(form.guardianName).toBe('');
-    expect(form.guardianSignature).toBe('');
+  it('starts with every typed field empty (signature dates are server-stamped, not form fields)', () => {
+    const form = emptyWaiverSignatureForm();
+    expect(form).toEqual({
+      participantName: '',
+      minorParticipantName: '',
+      minorDateOfBirth: '',
+      guardianName: '',
+      guardianSignature: '',
+    });
   });
 });
 
 describe('validateWaiverSignature', () => {
   describe('adult participant', () => {
-    it('accepts a valid adult-only form and builds the payload without minor fields', () => {
+    it('accepts a valid adult-only form and builds the payload without minor fields or dates', () => {
       const result = validateWaiverSignature(validAdultForm(), NOW);
 
       expect(result.valid).toBe(true);
       expect(result.errors).toEqual({});
       expect(result.details).toEqual({
         participantName: 'Jane Skater',
-        participantDate: '2026-07-21',
       });
     });
 
@@ -123,49 +122,28 @@ describe('validateWaiverSignature', () => {
       expect(result.errors.participantName).toBe('Printed name is required');
       expect(result.details).toBeNull();
     });
-
-    it('rejects an invalid participant date', () => {
-      const result = validateWaiverSignature(
-        { ...validAdultForm(), participantDate: '13/45/20' },
-        NOW
-      );
-
-      expect(result.valid).toBe(false);
-      expect(result.errors.participantDate).toBe('Enter a valid date (MM/DD/YYYY)');
-    });
-
-    it('rejects an emptied participant date', () => {
-      const result = validateWaiverSignature({ ...validAdultForm(), participantDate: '' }, NOW);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors.participantDate).toBeDefined();
-    });
   });
 
   describe('Parent/Guardian section (all-or-nothing)', () => {
-    it('accepts a fully filled minor section and includes it in the payload', () => {
+    it('accepts a fully filled minor section and includes it in the payload (no dates)', () => {
       const result = validateWaiverSignature(validMinorForm(), NOW);
 
       expect(result.valid).toBe(true);
       expect(result.details).toEqual({
         participantName: 'Jane Skater',
-        participantDate: '2026-07-21',
         minorParticipantName: 'Minor Player',
         minorDateOfBirth: '2014-03-05',
         guardianName: 'Pat Guardian',
         guardianSignature: 'Pat Guardian',
-        guardianDate: '2026-07-21',
       });
     });
 
-    it('treats an untouched section (only the pre-filled date) as empty', () => {
-      // guardianDate is pre-filled with today, so it must not by itself
-      // activate the all-or-nothing rule
+    it('treats an untouched section as empty', () => {
       const result = validateWaiverSignature(validAdultForm(), NOW);
 
       expect(result.valid).toBe(true);
-      expect(result.details?.guardianDate).toBeUndefined();
       expect(result.details?.minorParticipantName).toBeUndefined();
+      expect(result.details?.minorDateOfBirth).toBeUndefined();
     });
 
     it.each([
@@ -192,20 +170,6 @@ describe('validateWaiverSignature', () => {
           expect(result.errors[key]).toBeDefined();
         }
       }
-    });
-
-    it('requires the guardian date when the section is started and the date was cleared', () => {
-      const result = validateWaiverSignature({ ...validMinorForm(), guardianDate: '' }, NOW);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors.guardianDate).toBe('Date is required to complete this section');
-    });
-
-    it('rejects an invalid guardian date when the section is started', () => {
-      const result = validateWaiverSignature({ ...validMinorForm(), guardianDate: '02/30/2026' }, NOW);
-
-      expect(result.valid).toBe(false);
-      expect(result.errors.guardianDate).toBe('Enter a valid date (MM/DD/YYYY)');
     });
 
     it.each([

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-cont
 
 import * as Notifications from 'expo-notifications';
 import { initializeApiClient } from '@bhmhockey/api-client';
+import type { WaiverSignatureDetails } from '@bhmhockey/shared';
 import { getApiUrl } from '../config/api';
 import { colors } from '../theme';
 import { useAuthStore } from '../stores/authStore';
@@ -197,11 +198,11 @@ function RootLayoutContent() {
   // Accept-or-leave handlers for the blocking gate (one org at a time, queued)
   const currentPendingWaiver = pendingWaivers.length > 0 ? pendingWaivers[0] : null;
 
-  const handleGateAgree = async () => {
+  const handleGateAgree = async (signature: WaiverSignatureDetails) => {
     if (!currentPendingWaiver) return;
     const ok = await useWaiverStore
       .getState()
-      .acceptWaiver(currentPendingWaiver.organizationId, currentPendingWaiver.waiver.id);
+      .acceptWaiver(currentPendingWaiver.organizationId, currentPendingWaiver.waiver.id, signature);
     if (!ok) {
       Alert.alert(
         'Error',

--- a/apps/mobile/app/events/[id]/index.tsx
+++ b/apps/mobile/app/events/[id]/index.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../../components';
 import type { TabKey } from '../../../components';
 import { colors, spacing } from '../../../theme';
-import type { Position, RegistrationResultDto } from '@bhmhockey/shared';
+import type { Position, RegistrationResultDto, WaiverSignatureDetails } from '@bhmhockey/shared';
 
 export default function EventDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -224,12 +224,12 @@ export default function EventDetailScreen() {
 
   // Agree in the registration-flow waiver modal: accept, then continue straight
   // into the registration flow (position picker etc.) in the same gesture
-  const handleWaiverAgree = async () => {
+  const handleWaiverAgree = async (signature: WaiverSignatureDetails) => {
     if (!selectedEvent?.organizationId || !orgWaiver) return;
 
     const ok = await useWaiverStore
       .getState()
-      .acceptWaiver(selectedEvent.organizationId, orgWaiver.id);
+      .acceptWaiver(selectedEvent.organizationId, orgWaiver.id, signature);
 
     if (!ok) {
       setWaiverModalVisible(false);

--- a/apps/mobile/app/organizations/[id].tsx
+++ b/apps/mobile/app/organizations/[id].tsx
@@ -221,10 +221,13 @@ export default function OrganizationDetailScreen() {
 
   const isAdmin = organization?.isAdmin;
 
-  // Waiver status - flags are only non-null when the org has an active waiver
-  const waiverActive = members.some(
-    (m) => m.hasAcceptedCurrentWaiver !== null && m.hasAcceptedCurrentWaiver !== undefined
-  );
+  // Waiver status - ADMIN-ONLY visibility (the server also nulls the flags
+  // for non-admin requesters); flags are only non-null when an active waiver exists
+  const waiverActive =
+    !!isAdmin &&
+    members.some(
+      (m) => m.hasAcceptedCurrentWaiver !== null && m.hasAcceptedCurrentWaiver !== undefined
+    );
   const waiverAcceptedCount = members.filter((m) => m.hasAcceptedCurrentWaiver === true).length;
   const waiverNotAcceptedCount = members.filter((m) => m.hasAcceptedCurrentWaiver === false).length;
 
@@ -330,10 +333,10 @@ export default function OrganizationDetailScreen() {
                               {member.firstName} {member.lastName}
                             </Text>
                             {member.isAdmin && <Badge variant="purple">Admin</Badge>}
-                            {member.hasAcceptedCurrentWaiver === true && (
+                            {waiverActive && member.hasAcceptedCurrentWaiver === true && (
                               <Badge variant="green">Waiver ✓</Badge>
                             )}
-                            {member.hasAcceptedCurrentWaiver === false && (
+                            {waiverActive && member.hasAcceptedCurrentWaiver === false && (
                               <Badge variant="warning">No waiver</Badge>
                             )}
                             {isCurrentUser && <Text style={styles.youLabel}>(You)</Text>}

--- a/apps/mobile/app/organizations/[id].tsx
+++ b/apps/mobile/app/organizations/[id].tsx
@@ -13,6 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { organizationService } from '@bhmhockey/api-client';
 import { useOrganizationStore } from '../../stores/organizationStore';
 import { useAuthStore } from '../../stores/authStore';
+import { useWaiverStore } from '../../stores/waiverStore';
 import { Badge, SkillLevelBadges, BadgeIconsRow, MemberDetailModal } from '../../components';
 import { colors, spacing, radius } from '../../theme';
 import { shareOrganizationInvite } from '../../utils/share';
@@ -85,24 +86,51 @@ export default function OrganizationDetailScreen() {
       return;
     }
 
-    setIsProcessing(true);
+    if (organization.isSubscribed) {
+      // Leaving uses the leave endpoint (not plain unsubscribe) so upcoming
+      // registrations are cancelled too - same semantics as the waiver gate
+      Alert.alert(
+        'Leave Organization',
+        `Leave ${organization.name}? You will lose your registration for any upcoming events with this organization.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Leave',
+            style: 'destructive',
+            onPress: async () => {
+              setIsProcessing(true);
+              try {
+                const ok = await useWaiverStore.getState().leaveOrganization(organization.id);
+                if (!ok) {
+                  Alert.alert(
+                    'Error',
+                    useWaiverStore.getState().error || 'Failed to leave organization'
+                  );
+                  return;
+                }
+                setOrganization({
+                  ...organization,
+                  isSubscribed: false,
+                  subscriberCount: Math.max(0, organization.subscriberCount - 1),
+                });
+              } finally {
+                setIsProcessing(false);
+              }
+            },
+          },
+        ]
+      );
+      return;
+    }
 
+    setIsProcessing(true);
     try {
-      if (organization.isSubscribed) {
-        await unsubscribe(organization.id);
-        setOrganization({
-          ...organization,
-          isSubscribed: false,
-          subscriberCount: Math.max(0, organization.subscriberCount - 1),
-        });
-      } else {
-        await subscribe(organization.id);
-        setOrganization({
-          ...organization,
-          isSubscribed: true,
-          subscriberCount: organization.subscriberCount + 1,
-        });
-      }
+      await subscribe(organization.id);
+      setOrganization({
+        ...organization,
+        isSubscribed: true,
+        subscriberCount: organization.subscriberCount + 1,
+      });
     } catch (error) {
       Alert.alert('Error', 'Failed to update subscription');
     } finally {
@@ -375,9 +403,9 @@ export default function OrganizationDetailScreen() {
             ) : (
               <Text style={[
                 styles.subscribeButtonText,
-                organization.isSubscribed && styles.subscribedButtonText,
+                organization.isSubscribed && styles.leaveButtonText,
               ]}>
-                {organization.isSubscribed ? 'Joined' : 'Join Organization'}
+                {organization.isSubscribed ? 'Leave Organization' : 'Join Organization'}
               </Text>
             )}
           </TouchableOpacity>
@@ -649,6 +677,9 @@ const styles = StyleSheet.create({
   },
   subscribedButtonText: {
     color: colors.primary.teal,
+  },
+  leaveButtonText: {
+    color: colors.status.error,
   },
   hint: {
     textAlign: 'center',

--- a/apps/mobile/components/WaiverAcceptanceModal.tsx
+++ b/apps/mobile/components/WaiverAcceptanceModal.tsx
@@ -2,29 +2,40 @@ import { useEffect, useRef, useState } from 'react';
 import {
   View,
   Text,
+  TextInput,
   StyleSheet,
   Modal,
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
+  KeyboardAvoidingView,
   Linking,
   NativeSyntheticEvent,
   NativeScrollEvent,
+  Platform,
 } from 'react-native';
-import type { OrganizationWaiver } from '@bhmhockey/shared';
+import type { OrganizationWaiver, WaiverSignatureDetails } from '@bhmhockey/shared';
 import { getApiUrl } from '../config/api';
 import { parseWaiverSegments } from '../utils/waiverFormat';
+import {
+  emptyWaiverSignatureForm,
+  validateWaiverSignature,
+  type WaiverSignatureFormValues,
+} from '../utils/waiverSignature';
 import { colors, spacing, radius } from '../theme';
 
 // How close to the bottom (px) counts as "scrolled to the bottom"
 const SCROLL_BOTTOM_THRESHOLD = 24;
+
+// Matches the server-side cap on signature text fields
+const SIGNATURE_FIELD_MAX_LENGTH = 200;
 
 interface WaiverAcceptanceModalProps {
   visible: boolean;
   organizationName: string;
   waiver: OrganizationWaiver;
   /** Called after the user taps Agree (caller performs the accept API call) */
-  onAgree: () => void | Promise<void>;
+  onAgree: (signature: WaiverSignatureDetails) => void | Promise<void>;
   /**
    * Dismissible mode (registration flow): renders a Close button and allows
    * hardware-back dismissal. Omit for the blocking accept-or-leave gate.
@@ -34,9 +45,61 @@ interface WaiverAcceptanceModalProps {
   onLeaveOrganization?: () => void;
 }
 
+type FieldKey = keyof WaiverSignatureFormValues;
+
+interface SignatureFieldProps {
+  label: string;
+  value: string;
+  onChangeText: (value: string) => void;
+  onBlur: () => void;
+  error?: string;
+  placeholder?: string;
+  /** Renders the entered text in an italic "signature" style */
+  signature?: boolean;
+  isDate?: boolean;
+}
+
+function SignatureField({
+  label,
+  value,
+  onChangeText,
+  onBlur,
+  error,
+  placeholder,
+  signature,
+  isDate,
+}: SignatureFieldProps) {
+  return (
+    <View style={styles.field}>
+      <Text style={styles.fieldLabel} allowFontScaling={false}>{label}</Text>
+      <TextInput
+        style={[
+          styles.fieldInput,
+          signature && styles.signatureInput,
+          error != null && styles.fieldInputError,
+        ]}
+        value={value}
+        onChangeText={onChangeText}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        placeholderTextColor={colors.text.muted}
+        maxLength={isDate ? 10 : SIGNATURE_FIELD_MAX_LENGTH}
+        autoCapitalize={isDate ? 'none' : 'words'}
+        autoCorrect={false}
+        allowFontScaling={false}
+      />
+      {error != null && (
+        <Text style={styles.fieldError} allowFontScaling={false}>{error}</Text>
+      )}
+    </View>
+  );
+}
+
 /**
- * Full-screen legal waiver acceptance modal. The Agree button stays disabled
- * until the user has scrolled the waiver text to the bottom (enabled
+ * Full-screen legal waiver acceptance modal. Scrolling the waiver text to the
+ * bottom reveals the signature form (adult participant fields plus an optional
+ * all-or-nothing Parent/Guardian section for minors); the Agree button stays
+ * disabled until the text has been read AND the form validates (enabled
  * immediately when the text fits without scrolling).
  */
 export function WaiverAcceptanceModal({
@@ -49,16 +112,41 @@ export function WaiverAcceptanceModal({
 }: WaiverAcceptanceModalProps) {
   const [hasScrolledToBottom, setHasScrolledToBottom] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [form, setForm] = useState<WaiverSignatureFormValues>(emptyWaiverSignatureForm);
+  const [touched, setTouched] = useState<Partial<Record<FieldKey, boolean>>>({});
   const scrollViewHeightRef = useRef(0);
   const contentHeightRef = useRef(0);
 
-  // A new waiver version (or reopening) requires reading again
+  // A new waiver version (or reopening) requires reading and signing again
   useEffect(() => {
     if (visible) {
       setHasScrolledToBottom(false);
       setIsProcessing(false);
+      setForm(emptyWaiverSignatureForm());
+      setTouched({});
     }
   }, [visible, waiver.id]);
+
+  const validation = validateWaiverSignature(form);
+  const groupStarted =
+    form.minorParticipantName.trim().length > 0 ||
+    form.minorDateOfBirth.trim().length > 0 ||
+    form.guardianName.trim().length > 0 ||
+    form.guardianSignature.trim().length > 0;
+
+  const setField = (key: FieldKey) => (value: string) =>
+    setForm((current) => ({ ...current, [key]: value }));
+  const blurField = (key: FieldKey) => () =>
+    setTouched((current) => ({ ...current, [key]: true }));
+
+  // Inline errors appear once a field has been visited; minor-section errors
+  // also appear as soon as the section is started (the all-or-nothing rule
+  // must be visible without tabbing through every field)
+  const fieldError = (key: FieldKey, inMinorGroup = false): string | undefined => {
+    const error = validation.errors[key];
+    if (!error) return undefined;
+    return touched[key] || (inMinorGroup && groupStarted) ? error : undefined;
+  };
 
   const maybeEnableWithoutScrolling = () => {
     // If the content fits in the viewport there is nothing to scroll - enable
@@ -78,10 +166,13 @@ export function WaiverAcceptanceModal({
     }
   };
 
+  const canAgree = hasScrolledToBottom && validation.valid;
+
   const handleAgree = async () => {
+    if (!validation.details) return;
     setIsProcessing(true);
     try {
-      await onAgree();
+      await onAgree(validation.details);
     } finally {
       setIsProcessing(false);
     }
@@ -98,7 +189,10 @@ export function WaiverAcceptanceModal({
       animationType="slide"
       onRequestClose={onClose ?? (() => {})}
     >
-      <View style={styles.container}>
+      <KeyboardAvoidingView
+        style={styles.container}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
         <View style={styles.header}>
           <Text style={styles.title} allowFontScaling={false}>
             Legal Waiver
@@ -118,6 +212,7 @@ export function WaiverAcceptanceModal({
         <ScrollView
           style={styles.textScroll}
           contentContainerStyle={styles.textScrollContent}
+          keyboardShouldPersistTaps="handled"
           onLayout={(event) => {
             scrollViewHeightRef.current = event.nativeEvent.layout.height;
             maybeEnableWithoutScrolling();
@@ -138,6 +233,83 @@ export function WaiverAcceptanceModal({
               )
             )}
           </Text>
+
+          {/* Signature form - revealed once the waiver has been read to the bottom */}
+          {hasScrolledToBottom && (
+            <View style={styles.form}>
+              <Text style={styles.sectionHeader} allowFontScaling={false}>
+                Adult Participant
+              </Text>
+              <SignatureField
+                label="Printed Name"
+                value={form.participantName}
+                onChangeText={setField('participantName')}
+                onBlur={blurField('participantName')}
+                error={fieldError('participantName')}
+                placeholder="Full legal name"
+              />
+              <SignatureField
+                label="Date"
+                value={form.participantDate}
+                onChangeText={setField('participantDate')}
+                onBlur={blurField('participantDate')}
+                error={fieldError('participantDate')}
+                placeholder="MM/DD/YYYY"
+                isDate
+              />
+
+              <Text style={styles.sectionHeader} allowFontScaling={false}>
+                Parent/Guardian (required if participant is under 19)
+              </Text>
+              <Text style={styles.sectionHint} allowFontScaling={false}>
+                Leave this section empty unless the participant is under 19 years
+                of age. If you start it, every field is required.
+              </Text>
+              <SignatureField
+                label="Minor Participant's Printed Name"
+                value={form.minorParticipantName}
+                onChangeText={setField('minorParticipantName')}
+                onBlur={blurField('minorParticipantName')}
+                error={fieldError('minorParticipantName', true)}
+                placeholder="Minor's full legal name"
+              />
+              <SignatureField
+                label="Minor's Date of Birth"
+                value={form.minorDateOfBirth}
+                onChangeText={setField('minorDateOfBirth')}
+                onBlur={blurField('minorDateOfBirth')}
+                error={fieldError('minorDateOfBirth', true)}
+                placeholder="MM/DD/YYYY"
+                isDate
+              />
+              <SignatureField
+                label="Parent/Guardian Printed Name"
+                value={form.guardianName}
+                onChangeText={setField('guardianName')}
+                onBlur={blurField('guardianName')}
+                error={fieldError('guardianName', true)}
+                placeholder="Parent or guardian's full legal name"
+              />
+              <SignatureField
+                label="Parent/Guardian Signature"
+                value={form.guardianSignature}
+                onChangeText={setField('guardianSignature')}
+                onBlur={blurField('guardianSignature')}
+                error={fieldError('guardianSignature', true)}
+                placeholder="Type your full name to sign"
+                signature
+              />
+              <SignatureField
+                label="Date"
+                value={form.guardianDate}
+                onChangeText={setField('guardianDate')}
+                onBlur={blurField('guardianDate')}
+                error={fieldError('guardianDate', true)}
+                placeholder="MM/DD/YYYY"
+                isDate
+              />
+            </View>
+          )}
         </ScrollView>
 
         <View style={styles.footer}>
@@ -149,14 +321,19 @@ export function WaiverAcceptanceModal({
 
           {!hasScrolledToBottom && (
             <Text style={styles.scrollHint} allowFontScaling={false}>
-              Scroll to the bottom to enable Agree
+              Scroll to the bottom to continue
+            </Text>
+          )}
+          {hasScrolledToBottom && !validation.valid && (
+            <Text style={styles.scrollHint} allowFontScaling={false}>
+              Complete the acceptance form above to enable Agree
             </Text>
           )}
 
           <TouchableOpacity
-            style={[styles.agreeButton, (!hasScrolledToBottom || isProcessing) && styles.agreeButtonDisabled]}
+            style={[styles.agreeButton, (!canAgree || isProcessing) && styles.agreeButtonDisabled]}
             onPress={handleAgree}
-            disabled={!hasScrolledToBottom || isProcessing}
+            disabled={!canAgree || isProcessing}
           >
             {isProcessing ? (
               <ActivityIndicator color={colors.bg.darkest} />
@@ -187,7 +364,7 @@ export function WaiverAcceptanceModal({
             </TouchableOpacity>
           )}
         </View>
-      </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
@@ -234,6 +411,55 @@ const styles = StyleSheet.create({
   waiverTextBold: {
     fontWeight: '700',
     color: colors.text.primary,
+  },
+  form: {
+    marginTop: spacing.lg,
+    paddingTop: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border.default,
+  },
+  sectionHeader: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: colors.text.primary,
+    marginBottom: spacing.sm,
+  },
+  sectionHint: {
+    fontSize: 13,
+    color: colors.text.muted,
+    lineHeight: 18,
+    marginBottom: spacing.md,
+  },
+  field: {
+    marginBottom: spacing.md,
+  },
+  fieldLabel: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.text.secondary,
+    marginBottom: spacing.xs,
+  },
+  fieldInput: {
+    backgroundColor: colors.bg.elevated,
+    borderWidth: 1,
+    borderColor: colors.border.default,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    fontSize: 16,
+    color: colors.text.primary,
+  },
+  // Typed signature rendered in italic to suggest a signature
+  signatureInput: {
+    fontStyle: 'italic',
+    fontSize: 18,
+  },
+  fieldInputError: {
+    borderColor: colors.status.error,
+  },
+  fieldError: {
+    fontSize: 12,
+    color: colors.status.error,
+    marginTop: spacing.xs,
   },
   footer: {
     padding: spacing.lg,

--- a/apps/mobile/components/WaiverAcceptanceModal.tsx
+++ b/apps/mobile/components/WaiverAcceptanceModal.tsx
@@ -158,13 +158,24 @@ export function WaiverAcceptanceModal({
   const blurField = (key: FieldKey) => () =>
     setTouched((current) => ({ ...current, [key]: true }));
 
-  // Inline errors appear once a field has been visited; minor-section errors
-  // also appear as soon as the section is started (the all-or-nothing rule
-  // must be visible without tabbing through every field)
+  // Inline errors appear once a field has content or has been visited;
+  // minor-section errors also appear as soon as the section is started (the
+  // all-or-nothing rule must be visible without tabbing through every field).
+  // Errors must never require a blur the user has no reason to perform -
+  // adult-only signers may never leave the name field.
   const fieldError = (key: FieldKey, inMinorGroup = false): string | undefined => {
     const error = validation.errors[key];
     if (!error) return undefined;
-    return touched[key] || (inMinorGroup && groupStarted) ? error : undefined;
+    const hasContent = form[key].trim().length > 0;
+    return touched[key] || hasContent || (inMinorGroup && groupStarted) ? error : undefined;
+  };
+
+  // Single always-current line under Agree explaining what still blocks it
+  const blockingReason = (): string | null => {
+    if (!hasScrolledToBottom) return 'Scroll to the bottom to enable Agree';
+    if (validation.valid) return null;
+    if (validation.errors.participantName) return validation.errors.participantName;
+    return 'Complete the Parent/Guardian section - every field is required once started';
   };
 
   const maybeEnableWithoutScrolling = () => {
@@ -322,14 +333,9 @@ export function WaiverAcceptanceModal({
             </Text>
           </TouchableOpacity>
 
-          {!hasScrolledToBottom && (
+          {blockingReason() != null && (
             <Text style={styles.scrollHint} allowFontScaling={false}>
-              Scroll to the bottom to continue
-            </Text>
-          )}
-          {hasScrolledToBottom && !validation.valid && (
-            <Text style={styles.scrollHint} allowFontScaling={false}>
-              Complete the acceptance form above to enable Agree
+              {blockingReason()}
             </Text>
           )}
 

--- a/apps/mobile/components/WaiverAcceptanceModal.tsx
+++ b/apps/mobile/components/WaiverAcceptanceModal.tsx
@@ -19,6 +19,7 @@ import { getApiUrl } from '../config/api';
 import { parseWaiverSegments } from '../utils/waiverFormat';
 import {
   emptyWaiverSignatureForm,
+  todayMMDDYYYY,
   validateWaiverSignature,
   type WaiverSignatureFormValues,
 } from '../utils/waiverSignature';
@@ -57,6 +58,21 @@ interface SignatureFieldProps {
   /** Renders the entered text in an italic "signature" style */
   signature?: boolean;
   isDate?: boolean;
+}
+
+// Signature dates are always today and are stamped by the server at
+// acceptance time - shown read-only so they cannot be backdated
+function ReadOnlyDateField({ label }: { label: string }) {
+  return (
+    <View style={styles.field}>
+      <Text style={styles.fieldLabel} allowFontScaling={false}>{label}</Text>
+      <View style={[styles.fieldInput, styles.readOnlyField]}>
+        <Text style={styles.readOnlyFieldText} allowFontScaling={false}>
+          {todayMMDDYYYY()}
+        </Text>
+      </View>
+    </View>
+  );
 }
 
 function SignatureField({
@@ -248,15 +264,7 @@ export function WaiverAcceptanceModal({
                 error={fieldError('participantName')}
                 placeholder="Full legal name"
               />
-              <SignatureField
-                label="Date"
-                value={form.participantDate}
-                onChangeText={setField('participantDate')}
-                onBlur={blurField('participantDate')}
-                error={fieldError('participantDate')}
-                placeholder="MM/DD/YYYY"
-                isDate
-              />
+              <ReadOnlyDateField label="Date" />
 
               <Text style={styles.sectionHeader} allowFontScaling={false}>
                 Parent/Guardian (required if participant is under 19)
@@ -299,15 +307,7 @@ export function WaiverAcceptanceModal({
                 placeholder="Type your full name to sign"
                 signature
               />
-              <SignatureField
-                label="Date"
-                value={form.guardianDate}
-                onChangeText={setField('guardianDate')}
-                onBlur={blurField('guardianDate')}
-                error={fieldError('guardianDate', true)}
-                placeholder="MM/DD/YYYY"
-                isDate
-              />
+              <ReadOnlyDateField label="Date" />
             </View>
           )}
         </ScrollView>
@@ -452,6 +452,13 @@ const styles = StyleSheet.create({
   signatureInput: {
     fontStyle: 'italic',
     fontSize: 18,
+  },
+  readOnlyField: {
+    opacity: 0.7,
+  },
+  readOnlyFieldText: {
+    fontSize: 16,
+    color: colors.text.secondary,
   },
   fieldInputError: {
     borderColor: colors.status.error,

--- a/apps/mobile/components/WaiverAcceptanceModal.tsx
+++ b/apps/mobile/components/WaiverAcceptanceModal.tsx
@@ -15,6 +15,7 @@ import {
   Platform,
 } from 'react-native';
 import type { OrganizationWaiver, WaiverSignatureDetails } from '@bhmhockey/shared';
+import { useAuthStore } from '../stores/authStore';
 import { getApiUrl } from '../config/api';
 import { parseWaiverSegments } from '../utils/waiverFormat';
 import {
@@ -143,7 +144,9 @@ export function WaiverAcceptanceModal({
     }
   }, [visible, waiver.id]);
 
-  const validation = validateWaiverSignature(form);
+  const user = useAuthStore((state) => state.user);
+  const profileName = user ? `${user.firstName} ${user.lastName}` : undefined;
+  const validation = validateWaiverSignature(form, new Date(), profileName);
   const groupStarted =
     form.minorParticipantName.trim().length > 0 ||
     form.minorDateOfBirth.trim().length > 0 ||

--- a/apps/mobile/stores/organizationStore.ts
+++ b/apps/mobile/stores/organizationStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { organizationService } from '@bhmhockey/api-client';
 import type { Organization, OrganizationSubscription, CreateOrganizationRequest, OrganizationMember, AutoRosterMember, Position, OrganizationWaiver } from '@bhmhockey/shared';
+import { useEventStore } from './eventStore';
 
 /** Extract message from ApiError objects or Error instances */
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -130,6 +131,9 @@ export const useOrganizationStore = create<OrganizationState>((set, get) => ({
       await organizationService.subscribe(organizationId);
       // Refresh subscriptions to get full data
       await get().fetchMySubscriptions();
+      // Membership changes event visibility - refresh so the org's events
+      // appear without a manual pull-to-refresh (failure is non-fatal)
+      await useEventStore.getState().fetchEvents().catch(() => {});
     } catch (error) {
       // Rollback optimistic update - restore original state
       set({
@@ -154,6 +158,8 @@ export const useOrganizationStore = create<OrganizationState>((set, get) => ({
 
     try {
       await organizationService.unsubscribe(organizationId);
+      // Membership changes event visibility - keep the events list current
+      await useEventStore.getState().fetchEvents().catch(() => {});
     } catch (error) {
       // Rollback optimistic update
       set({

--- a/apps/mobile/stores/waiverStore.ts
+++ b/apps/mobile/stores/waiverStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { organizationService } from '@bhmhockey/api-client';
 import type { PendingWaiver, WaiverSignatureDetails } from '@bhmhockey/shared';
+import { useOrganizationStore } from './organizationStore';
+import { useEventStore } from './eventStore';
 
 /** Extract message from ApiError objects or Error instances */
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -83,6 +85,14 @@ export const useWaiverStore = create<WaiverState>((set, get) => ({
       set((state) => ({
         pendingWaivers: state.pendingWaivers.filter((p) => p.organizationId !== organizationId),
       }));
+      // Leaving changes org membership AND cancels registrations - refresh the
+      // org list and event lists so every screen is current without a manual
+      // pull-to-refresh. Refresh failures don't undo the successful leave.
+      await Promise.all([
+        useOrganizationStore.getState().fetchOrganizations(),
+        useEventStore.getState().fetchEvents(),
+        useEventStore.getState().fetchMyRegistrations(),
+      ]).catch(() => {});
       return true;
     } catch (error) {
       set({ error: getErrorMessage(error, 'Failed to leave organization') });

--- a/apps/mobile/stores/waiverStore.ts
+++ b/apps/mobile/stores/waiverStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { organizationService } from '@bhmhockey/api-client';
-import type { PendingWaiver } from '@bhmhockey/shared';
+import type { PendingWaiver, WaiverSignatureDetails } from '@bhmhockey/shared';
 
 /** Extract message from ApiError objects or Error instances */
 function getErrorMessage(error: unknown, fallback: string): string {
@@ -19,7 +19,11 @@ interface WaiverState {
 
   // Actions
   fetchPendingWaivers: () => Promise<void>;
-  acceptWaiver: (organizationId: string, waiverId: string) => Promise<boolean>;
+  acceptWaiver: (
+    organizationId: string,
+    waiverId: string,
+    signature: WaiverSignatureDetails
+  ) => Promise<boolean>;
   leaveOrganization: (organizationId: string) => Promise<boolean>;
   reset: () => void;
 }
@@ -47,10 +51,15 @@ export const useWaiverStore = create<WaiverState>((set, get) => ({
     }
   },
 
-  // Accept a specific waiver version; removes the org from the pending queue
-  acceptWaiver: async (organizationId: string, waiverId: string) => {
+  // Accept a specific waiver version, recording the signature fields captured
+  // on the acceptance form; removes the org from the pending queue
+  acceptWaiver: async (
+    organizationId: string,
+    waiverId: string,
+    signature: WaiverSignatureDetails
+  ) => {
     try {
-      await organizationService.acceptWaiver(organizationId, waiverId);
+      await organizationService.acceptWaiver(organizationId, waiverId, signature);
       set((state) => ({
         pendingWaivers: state.pendingWaivers.filter((p) => p.organizationId !== organizationId),
       }));

--- a/apps/mobile/utils/waiverSignature.ts
+++ b/apps/mobile/utils/waiverSignature.ts
@@ -5,9 +5,10 @@ import type { WaiverSignatureDetails } from '@bhmhockey/shared';
  * client-side validation rules (mirrored server-side in
  * OrganizationWaiverService.ValidateSignatureFields):
  * - Printed name required (non-empty trimmed)
- * - Date required, must parse as a real calendar date
  * - Parent/Guardian section is all-or-nothing; when active, the minor's
  *   date of birth must be a valid date in the past
+ * Signature dates are displayed read-only (always today) and stamped by
+ * the server - they are not part of the form payload.
  */
 
 // A parsed calendar date (no time component, no timezone)
@@ -71,22 +72,18 @@ export function isPastDate(date: CalendarDate, now: Date = new Date()): boolean 
 // Raw form values as typed by the user (all plain text inputs)
 export interface WaiverSignatureFormValues {
   participantName: string;
-  participantDate: string;
   minorParticipantName: string;
   minorDateOfBirth: string;
   guardianName: string;
   guardianSignature: string;
-  guardianDate: string;
 }
 
-export const emptyWaiverSignatureForm = (now: Date = new Date()): WaiverSignatureFormValues => ({
+export const emptyWaiverSignatureForm = (): WaiverSignatureFormValues => ({
   participantName: '',
-  participantDate: todayMMDDYYYY(now),
   minorParticipantName: '',
   minorDateOfBirth: '',
   guardianName: '',
   guardianSignature: '',
-  guardianDate: todayMMDDYYYY(now),
 });
 
 export interface WaiverSignatureValidation {
@@ -102,10 +99,9 @@ const DATE_ERROR = 'Enter a valid date (MM/DD/YYYY)';
  * Validate the acceptance form and build the API payload.
  *
  * The Parent/Guardian group counts as "started" when any of its typed fields
- * (minor name, date of birth, guardian name, signature) is non-empty. The
- * guardian Date field is excluded from that check because it is pre-filled
- * with today - otherwise the group could never be "entirely empty". When the
- * group is empty, no minor fields (including the pre-filled date) are sent.
+ * (minor name, date of birth, guardian name, signature) is non-empty. When
+ * the group is empty, no minor fields are sent. Signature dates are not
+ * validated or sent - the server stamps them at acceptance time.
  */
 export function validateWaiverSignature(
   values: WaiverSignatureFormValues,
@@ -116,10 +112,6 @@ export function validateWaiverSignature(
   const participantName = values.participantName.trim();
   if (!participantName) {
     errors.participantName = 'Printed name is required';
-  }
-  const participantDate = parseDateInput(values.participantDate);
-  if (!participantDate) {
-    errors.participantDate = DATE_ERROR;
   }
 
   const minorParticipantName = values.minorParticipantName.trim();
@@ -134,7 +126,6 @@ export function validateWaiverSignature(
     guardianSignature.length > 0;
 
   let minorDateOfBirth: CalendarDate | null = null;
-  let guardianDate: CalendarDate | null = null;
 
   if (groupStarted) {
     if (!minorParticipantName) {
@@ -156,12 +147,6 @@ export function validateWaiverSignature(
     if (!guardianSignature) {
       errors.guardianSignature = 'Signature is required to complete this section';
     }
-    guardianDate = parseDateInput(values.guardianDate);
-    if (!guardianDate) {
-      errors.guardianDate = values.guardianDate.trim()
-        ? DATE_ERROR
-        : 'Date is required to complete this section';
-    }
   }
 
   if (Object.keys(errors).length > 0) {
@@ -170,14 +155,12 @@ export function validateWaiverSignature(
 
   const details: WaiverSignatureDetails = {
     participantName,
-    participantDate: toIsoDate(participantDate!),
     ...(groupStarted
       ? {
           minorParticipantName,
           minorDateOfBirth: toIsoDate(minorDateOfBirth!),
           guardianName,
           guardianSignature,
-          guardianDate: toIsoDate(guardianDate!),
         }
       : {}),
   };

--- a/apps/mobile/utils/waiverSignature.ts
+++ b/apps/mobile/utils/waiverSignature.ts
@@ -96,6 +96,16 @@ export interface WaiverSignatureValidation {
 const DATE_ERROR = 'Enter a valid date (MM/DD/YYYY)';
 
 /**
+ * Case-insensitive, whitespace-normalized comparison - mirrors the server's
+ * OrganizationWaiverService.NamesMatch; keep the two in sync.
+ */
+function namesMatch(entered: string, profileName: string): boolean {
+  const normalize = (value: string) =>
+    value.trim().split(/\s+/).join(' ').toLowerCase();
+  return normalize(entered) === normalize(profileName);
+}
+
+/**
  * Validate the acceptance form and build the API payload.
  *
  * The Parent/Guardian group counts as "started" when any of its typed fields
@@ -105,13 +115,21 @@ const DATE_ERROR = 'Enter a valid date (MM/DD/YYYY)';
  */
 export function validateWaiverSignature(
   values: WaiverSignatureFormValues,
-  now: Date = new Date()
+  now: Date = new Date(),
+  // The account holder's profile name; when provided, the adult printed
+  // name must match it (also enforced server-side)
+  expectedParticipantName?: string
 ): WaiverSignatureValidation {
   const errors: WaiverSignatureValidation['errors'] = {};
 
   const participantName = values.participantName.trim();
   if (!participantName) {
     errors.participantName = 'Printed name is required';
+  } else if (
+    expectedParticipantName &&
+    !namesMatch(participantName, expectedParticipantName)
+  ) {
+    errors.participantName = `Must match the name on your profile: ${expectedParticipantName}`;
   }
 
   const minorParticipantName = values.minorParticipantName.trim();

--- a/apps/mobile/utils/waiverSignature.ts
+++ b/apps/mobile/utils/waiverSignature.ts
@@ -30,7 +30,13 @@ export function todayMMDDYYYY(now: Date = new Date()): string {
  * required) into a calendar date. Returns null for anything that is not a
  * real calendar date (e.g. 02/30/2026).
  */
-export function parseDateInput(value: string): CalendarDate | null {
+export function parseDateInput(value: string | null | undefined): CalendarDate | null {
+  // Defensive: this validator guards the blocking waiver gate - a thrown
+  // error here fails the gate OPEN (crash = no gate), so bad input must
+  // return null, never throw
+  if (typeof value !== 'string') {
+    return null;
+  }
   const match = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(value.trim());
   if (!match) {
     return null;

--- a/apps/mobile/utils/waiverSignature.ts
+++ b/apps/mobile/utils/waiverSignature.ts
@@ -1,0 +1,186 @@
+import type { WaiverSignatureDetails } from '@bhmhockey/shared';
+
+/**
+ * Waiver acceptance signature form: MM/DD/YYYY date helpers and the
+ * client-side validation rules (mirrored server-side in
+ * OrganizationWaiverService.ValidateSignatureFields):
+ * - Printed name required (non-empty trimmed)
+ * - Date required, must parse as a real calendar date
+ * - Parent/Guardian section is all-or-nothing; when active, the minor's
+ *   date of birth must be a valid date in the past
+ */
+
+// A parsed calendar date (no time component, no timezone)
+interface CalendarDate {
+  year: number;
+  month: number; // 1-12
+  day: number;   // 1-31
+}
+
+/** Today's date on the local device clock, formatted MM/DD/YYYY */
+export function todayMMDDYYYY(now: Date = new Date()): string {
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${month}/${day}/${now.getFullYear()}`;
+}
+
+/**
+ * Parse an MM/DD/YYYY input (1-2 digit month/day accepted, 4-digit year
+ * required) into a calendar date. Returns null for anything that is not a
+ * real calendar date (e.g. 02/30/2026).
+ */
+export function parseDateInput(value: string): CalendarDate | null {
+  const match = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+
+  const month = parseInt(match[1], 10);
+  const day = parseInt(match[2], 10);
+  const year = parseInt(match[3], 10);
+  if (month < 1 || month > 12) {
+    return null;
+  }
+  // Date.UTC never throws - verify no rollover (e.g. 02/30 -> 03/02)
+  const check = new Date(Date.UTC(year, month - 1, day));
+  if (
+    check.getUTCFullYear() !== year ||
+    check.getUTCMonth() !== month - 1 ||
+    check.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return { year, month, day };
+}
+
+/** ISO calendar date (YYYY-MM-DD) - the wire format the API expects */
+export function toIsoDate(date: CalendarDate): string {
+  const month = String(date.month).padStart(2, '0');
+  const day = String(date.day).padStart(2, '0');
+  return `${date.year}-${month}-${day}`;
+}
+
+/** True when the date is strictly before today on the local device clock */
+export function isPastDate(date: CalendarDate, now: Date = new Date()): boolean {
+  const value = date.year * 10000 + date.month * 100 + date.day;
+  const today = now.getFullYear() * 10000 + (now.getMonth() + 1) * 100 + now.getDate();
+  return value < today;
+}
+
+// Raw form values as typed by the user (all plain text inputs)
+export interface WaiverSignatureFormValues {
+  participantName: string;
+  participantDate: string;
+  minorParticipantName: string;
+  minorDateOfBirth: string;
+  guardianName: string;
+  guardianSignature: string;
+  guardianDate: string;
+}
+
+export const emptyWaiverSignatureForm = (now: Date = new Date()): WaiverSignatureFormValues => ({
+  participantName: '',
+  participantDate: todayMMDDYYYY(now),
+  minorParticipantName: '',
+  minorDateOfBirth: '',
+  guardianName: '',
+  guardianSignature: '',
+  guardianDate: todayMMDDYYYY(now),
+});
+
+export interface WaiverSignatureValidation {
+  valid: boolean;
+  errors: Partial<Record<keyof WaiverSignatureFormValues, string>>;
+  /** API payload - only present when valid */
+  details: WaiverSignatureDetails | null;
+}
+
+const DATE_ERROR = 'Enter a valid date (MM/DD/YYYY)';
+
+/**
+ * Validate the acceptance form and build the API payload.
+ *
+ * The Parent/Guardian group counts as "started" when any of its typed fields
+ * (minor name, date of birth, guardian name, signature) is non-empty. The
+ * guardian Date field is excluded from that check because it is pre-filled
+ * with today - otherwise the group could never be "entirely empty". When the
+ * group is empty, no minor fields (including the pre-filled date) are sent.
+ */
+export function validateWaiverSignature(
+  values: WaiverSignatureFormValues,
+  now: Date = new Date()
+): WaiverSignatureValidation {
+  const errors: WaiverSignatureValidation['errors'] = {};
+
+  const participantName = values.participantName.trim();
+  if (!participantName) {
+    errors.participantName = 'Printed name is required';
+  }
+  const participantDate = parseDateInput(values.participantDate);
+  if (!participantDate) {
+    errors.participantDate = DATE_ERROR;
+  }
+
+  const minorParticipantName = values.minorParticipantName.trim();
+  const minorDateOfBirthText = values.minorDateOfBirth.trim();
+  const guardianName = values.guardianName.trim();
+  const guardianSignature = values.guardianSignature.trim();
+
+  const groupStarted =
+    minorParticipantName.length > 0 ||
+    minorDateOfBirthText.length > 0 ||
+    guardianName.length > 0 ||
+    guardianSignature.length > 0;
+
+  let minorDateOfBirth: CalendarDate | null = null;
+  let guardianDate: CalendarDate | null = null;
+
+  if (groupStarted) {
+    if (!minorParticipantName) {
+      errors.minorParticipantName = "Minor's name is required to complete this section";
+    }
+    if (!minorDateOfBirthText) {
+      errors.minorDateOfBirth = 'Date of birth is required to complete this section';
+    } else {
+      minorDateOfBirth = parseDateInput(minorDateOfBirthText);
+      if (!minorDateOfBirth) {
+        errors.minorDateOfBirth = DATE_ERROR;
+      } else if (!isPastDate(minorDateOfBirth, now)) {
+        errors.minorDateOfBirth = 'Date of birth must be in the past';
+      }
+    }
+    if (!guardianName) {
+      errors.guardianName = 'Parent/guardian name is required to complete this section';
+    }
+    if (!guardianSignature) {
+      errors.guardianSignature = 'Signature is required to complete this section';
+    }
+    guardianDate = parseDateInput(values.guardianDate);
+    if (!guardianDate) {
+      errors.guardianDate = values.guardianDate.trim()
+        ? DATE_ERROR
+        : 'Date is required to complete this section';
+    }
+  }
+
+  if (Object.keys(errors).length > 0) {
+    return { valid: false, errors, details: null };
+  }
+
+  const details: WaiverSignatureDetails = {
+    participantName,
+    participantDate: toIsoDate(participantDate!),
+    ...(groupStarted
+      ? {
+          minorParticipantName,
+          minorDateOfBirth: toIsoDate(minorDateOfBirth!),
+          guardianName,
+          guardianSignature,
+          guardianDate: toIsoDate(guardianDate!),
+        }
+      : {}),
+  };
+
+  return { valid: true, errors: {}, details };
+}

--- a/packages/api-client/__tests__/services/organizations.test.ts
+++ b/packages/api-client/__tests__/services/organizations.test.ts
@@ -151,13 +151,43 @@ describe('organizationService waivers', () => {
   });
 
   describe('acceptWaiver', () => {
-    it('posts the specific waiver id to the accept endpoint', async () => {
+    it('posts the waiver id and adult signature fields to the accept endpoint', async () => {
       mockPost.mockResolvedValueOnce({});
 
-      await organizationService.acceptWaiver('org-1', 'waiver-1');
+      await organizationService.acceptWaiver('org-1', 'waiver-1', {
+        participantName: 'Jane Skater',
+        participantDate: '2026-07-21',
+      });
 
       expect(mockPost).toHaveBeenCalledWith('/organizations/org-1/waiver/accept', {
         waiverId: 'waiver-1',
+        participantName: 'Jane Skater',
+        participantDate: '2026-07-21',
+      });
+    });
+
+    it('posts the full Parent/Guardian section when provided', async () => {
+      mockPost.mockResolvedValueOnce({});
+
+      await organizationService.acceptWaiver('org-1', 'waiver-1', {
+        participantName: 'Pat Guardian',
+        participantDate: '2026-07-21',
+        minorParticipantName: 'Minor Player',
+        minorDateOfBirth: '2014-03-05',
+        guardianName: 'Pat Guardian',
+        guardianSignature: 'Pat Guardian',
+        guardianDate: '2026-07-21',
+      });
+
+      expect(mockPost).toHaveBeenCalledWith('/organizations/org-1/waiver/accept', {
+        waiverId: 'waiver-1',
+        participantName: 'Pat Guardian',
+        participantDate: '2026-07-21',
+        minorParticipantName: 'Minor Player',
+        minorDateOfBirth: '2014-03-05',
+        guardianName: 'Pat Guardian',
+        guardianSignature: 'Pat Guardian',
+        guardianDate: '2026-07-21',
       });
     });
   });

--- a/packages/api-client/__tests__/services/organizations.test.ts
+++ b/packages/api-client/__tests__/services/organizations.test.ts
@@ -156,13 +156,11 @@ describe('organizationService waivers', () => {
 
       await organizationService.acceptWaiver('org-1', 'waiver-1', {
         participantName: 'Jane Skater',
-        participantDate: '2026-07-21',
       });
 
       expect(mockPost).toHaveBeenCalledWith('/organizations/org-1/waiver/accept', {
         waiverId: 'waiver-1',
         participantName: 'Jane Skater',
-        participantDate: '2026-07-21',
       });
     });
 
@@ -171,23 +169,19 @@ describe('organizationService waivers', () => {
 
       await organizationService.acceptWaiver('org-1', 'waiver-1', {
         participantName: 'Pat Guardian',
-        participantDate: '2026-07-21',
         minorParticipantName: 'Minor Player',
         minorDateOfBirth: '2014-03-05',
         guardianName: 'Pat Guardian',
         guardianSignature: 'Pat Guardian',
-        guardianDate: '2026-07-21',
       });
 
       expect(mockPost).toHaveBeenCalledWith('/organizations/org-1/waiver/accept', {
         waiverId: 'waiver-1',
         participantName: 'Pat Guardian',
-        participantDate: '2026-07-21',
         minorParticipantName: 'Minor Player',
         minorDateOfBirth: '2014-03-05',
         guardianName: 'Pat Guardian',
         guardianSignature: 'Pat Guardian',
-        guardianDate: '2026-07-21',
       });
     });
   });

--- a/packages/api-client/src/services/organizations.ts
+++ b/packages/api-client/src/services/organizations.ts
@@ -12,6 +12,7 @@ import type {
   SetOrganizationWaiverRequest,
   SetOrganizationWaiverResponse,
   AcceptWaiverRequest,
+  WaiverSignatureDetails,
   PendingWaiver
 } from '@bhmhockey/shared';
 import { apiClient } from '../client';
@@ -190,10 +191,16 @@ export const organizationService = {
   },
 
   /**
-   * Accept a SPECIFIC waiver version (400 when the id is stale)
+   * Accept a SPECIFIC waiver version (400 when the id is stale), recording the
+   * signature fields captured on the acceptance form (400 when the participant
+   * name/date is missing or the Parent/Guardian section is partially filled)
    */
-  async acceptWaiver(organizationId: string, waiverId: string): Promise<void> {
-    const request: AcceptWaiverRequest = { waiverId };
+  async acceptWaiver(
+    organizationId: string,
+    waiverId: string,
+    signature: WaiverSignatureDetails
+  ): Promise<void> {
+    const request: AcceptWaiverRequest = { waiverId, ...signature };
     await apiClient.instance.post(`/organizations/${organizationId}/waiver/accept`, request);
   },
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -123,8 +123,24 @@ export interface SetOrganizationWaiverResponse {
   waiver: OrganizationWaiver | null;
 }
 
-// Accept a SPECIFIC waiver version (stale ids are rejected with 400)
-export interface AcceptWaiverRequest {
+// Signature fields captured on the acceptance form and recorded once on the
+// acceptance row (immutable audit data). Dates are calendar dates sent as
+// YYYY-MM-DD. participantName/participantDate are always required; the
+// Parent/Guardian section is all-or-nothing (required if the participant is
+// under 19): either every minor field is present or all are omitted.
+export interface WaiverSignatureDetails {
+  participantName: string;
+  participantDate: string;      // YYYY-MM-DD
+  minorParticipantName?: string;
+  minorDateOfBirth?: string;    // YYYY-MM-DD, must be in the past
+  guardianName?: string;
+  guardianSignature?: string;   // Typed signature (plain text)
+  guardianDate?: string;        // YYYY-MM-DD
+}
+
+// Accept a SPECIFIC waiver version (stale ids are rejected with 400) with the
+// signature fields recorded at acceptance
+export interface AcceptWaiverRequest extends WaiverSignatureDetails {
   waiverId: string;
 }
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -128,14 +128,14 @@ export interface SetOrganizationWaiverResponse {
 // YYYY-MM-DD. participantName/participantDate are always required; the
 // Parent/Guardian section is all-or-nothing (required if the participant is
 // under 19): either every minor field is present or all are omitted.
+// Signature dates are stamped server-side at acceptance time - the client
+// never sends them.
 export interface WaiverSignatureDetails {
   participantName: string;
-  participantDate: string;      // YYYY-MM-DD
   minorParticipantName?: string;
   minorDateOfBirth?: string;    // YYYY-MM-DD, must be in the past
   guardianName?: string;
   guardianSignature?: string;   // Typed signature (plain text)
-  guardianDate?: string;        // YYYY-MM-DD
 }
 
 // Accept a SPECIFIC waiver version (stale ids are rejected with 400) with the


### PR DESCRIPTION
## Summary

Extends waiver acceptance into a proper attestation, widens the blocking gate to all org members, and folds in twelve fixes from extensive live testing.

## Signature form (after scroll-to-bottom)

- **Adult participant**: printed name (required) — and it must **match the account's profile name** (case-insensitive, whitespace-normalized), enforced server-side with a mirrored live client check that names the expected value.
- **Parent/Guardian section** (required if the participant is under 19): minor's printed name, date of birth (validated, must be past), guardian printed name, typed signature (italic) — **all-or-nothing** as a group, enforced on both sides.
- **Signature dates are server-stamped** at acceptance time and shown read-only (always today) — the client never sends them, so signatures cannot be backdated by any means. Minor's DOB remains a client input.
- Acceptance rows stay immutable: re-accepting the same version preserves the originally recorded signature exactly.
- Form UX: errors render as soon as a field has content (no blur required), and the footer hint always states the specific blocker (scroll / name problem / incomplete guardian section). Fields sit in the same modal used by both the pre-registration flow and the blocking gate; keyboard-avoiding verified.

## Gate scope change (user decision)

`GET /users/me/pending-waivers` now gates **every subscriber** of an org with an active waiver, unioned with the previous held-registration condition (so non-member manual adds stay covered). Members must accept the current version or leave the org.

## Fixes from testing

- **Privacy**: member waiver-acceptance badges and the accepted/not summary were visible to non-admin subscribers — now admin-only, gated server-side (flags nulled, matching email gating) and client-side, with a regression test.
- **Explicit "Leave Organization" button** on the org page (was a silent "Joined" toggle that only unsubscribed) — now uses the leave endpoint (cancels upcoming registrations) with a confirmation warning, matching the waiver gate's semantics.
- **Automatic list refreshes**: leaving refreshes orgs/events/registrations; joining and unsubscribing refresh events — no more stale tabs until pull-to-refresh.
- **Fail-safe gate rendering**: waiver date parsing is defensive (returns null, never throws) so a validator error can never crash the blocking gate into failing open.

## Testing

- API: 1077 → 1105 (validation matrix, name matching loose/strict, stamped dates, idempotency-preserves-original, membership vs registration gating, privacy gating, storage round-trips)
- Frontend: mobile 110 → 150, api-client 39 → 40, shared 41; type-check clean
- Live E2E on a throwaway org (adult/minor/partial/invalid paths, idempotency, new-version re-gating, regressions) plus extensive manual simulator testing by @auc0le across admin and member accounts

Additive-only migration (7 nullable columns on WaiverAcceptances). DTOs mirrored in `@bhmhockey/shared`. No notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)