### PR TITLE
Code-review follow-ups: failure-path logging, auto-roster atomicity, dedup

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Controllers/UsersControllerTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Controllers/UsersControllerTests.cs
@@ -4,6 +4,7 @@ using BHMHockey.Api.Services;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using System.Security.Claims;
 using Xunit;
@@ -41,7 +42,8 @@ public class UsersControllerTests
             _mockBadgeService.Object,
             _mockTournamentTeamMemberService.Object,
             _mockTournamentService.Object,
-            _mockWaiverService.Object);
+            _mockWaiverService.Object,
+            Mock.Of<ILogger<UsersController>>());
     }
 
     private void SetupControllerWithClaims(IEnumerable<Claim> claims)

--- a/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/OrganizationServiceTests.cs
@@ -47,7 +47,7 @@ public class OrganizationServiceTests : IDisposable
             _mockWaitlistService.Object,
             _waiverService,
             Mock.Of<ILogger<EventService>>());
-        _sut = new OrganizationService(_context, _adminService, _waiverService, _eventService);
+        _sut = new OrganizationService(_context, _adminService, _waiverService, _eventService, Mock.Of<ILogger<OrganizationService>>());
     }
 
     public void Dispose()

--- a/apps/api/BHMHockey.Api/Controllers/EventsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/EventsController.cs
@@ -632,8 +632,10 @@ public class EventsController : ControllerBase
                 eventId, organizerId, userId, request.FirstName, request.LastName, request.Position, request.SkillLevel);
             return Ok(registration);
         }
-        catch (UnauthorizedAccessException)
+        catch (UnauthorizedAccessException ex)
         {
+            _logger.LogWarning("Ghost player update denied for event {EventId}, user {UserId}: {Message}",
+                eventId, userId, ex.Message);
             return Forbid();
         }
         catch (InvalidOperationException ex)

--- a/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/OrganizationsController.cs
@@ -235,8 +235,16 @@ public class OrganizationsController : ControllerBase
     public async Task<IActionResult> Leave(Guid id)
     {
         var userId = GetCurrentUserId();
-        await _organizationService.LeaveAsync(id, userId);
-        return Ok(new { message = "You have left the organization" });
+        try
+        {
+            await _organizationService.LeaveAsync(id, userId);
+            return Ok(new { message = "You have left the organization" });
+        }
+        catch (InvalidOperationException ex)
+        {
+            _logger.LogWarning("Leave organization rejected for organization {OrganizationId}, user {UserId}: {Message}", id, userId, ex.Message);
+            return BadRequest(new { message = ex.Message });
+        }
     }
 
     // Waiver endpoints

--- a/apps/api/BHMHockey.Api/Controllers/UsersController.cs
+++ b/apps/api/BHMHockey.Api/Controllers/UsersController.cs
@@ -18,6 +18,7 @@ public class UsersController : ControllerBase
     private readonly ITournamentTeamMemberService _tournamentTeamMemberService;
     private readonly ITournamentService _tournamentService;
     private readonly IOrganizationWaiverService _waiverService;
+    private readonly ILogger<UsersController> _logger;
 
     public UsersController(
         IUserService userService,
@@ -26,7 +27,8 @@ public class UsersController : ControllerBase
         IBadgeService badgeService,
         ITournamentTeamMemberService tournamentTeamMemberService,
         ITournamentService tournamentService,
-        IOrganizationWaiverService waiverService)
+        IOrganizationWaiverService waiverService,
+        ILogger<UsersController> logger)
     {
         _userService = userService;
         _organizationService = organizationService;
@@ -35,6 +37,7 @@ public class UsersController : ControllerBase
         _tournamentTeamMemberService = tournamentTeamMemberService;
         _tournamentService = tournamentService;
         _waiverService = waiverService;
+        _logger = logger;
     }
 
     private Guid GetCurrentUserId()
@@ -189,6 +192,7 @@ public class UsersController : ControllerBase
         }
         catch (UnauthorizedAccessException ex)
         {
+            _logger.LogWarning("Pending waivers request unauthorized: {Message}", ex.Message);
             return Unauthorized(new { message = ex.Message });
         }
     }

--- a/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/WaiverDTOs.cs
@@ -21,7 +21,7 @@ public record SetOrganizationWaiverResponse(
 
 // Accept a SPECIFIC waiver version (stale ids are rejected with 400).
 // Signature fields are recorded once on the acceptance row (immutable audit
-// data). ParticipantName/ParticipantDate are required (400 when missing or
+// data). ParticipantName is required (400 when missing or
 // blank). The Parent/Guardian section is all-or-nothing: either every minor
 // field is provided (participant under 19) or all are omitted (400 when
 // partially filled). Dates are calendar dates (client sends YYYY-MM-DD).

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -2168,12 +2168,14 @@ public class EventService : IEventService
 
         if (evt == null)
         {
+            _logger.LogWarning("Ghost player update failed: event {EventId} not found", eventId);
             throw new InvalidOperationException("Event not found");
         }
 
         // Verify organizer can manage this event
         if (!await CanUserManageEventAsync(evt, organizerId))
         {
+            _logger.LogWarning("Ghost player update denied: user {OrganizerId} cannot manage event {EventId}", organizerId, eventId);
             throw new UnauthorizedAccessException("You don't have permission to manage this event");
         }
 
@@ -2182,6 +2184,7 @@ public class EventService : IEventService
         var normalizedPositionKey = registeredPosition.ToLowerInvariant();
         if (!string.IsNullOrEmpty(skillLevel) && !ValidSkillLevels.Contains(skillLevel))
         {
+            _logger.LogWarning("Ghost player update rejected for event {EventId}: invalid skill level '{SkillLevel}'", eventId, skillLevel);
             throw new InvalidOperationException($"Invalid skill level: '{skillLevel}'. Valid values: Gold, Silver, Bronze, D-League");
         }
 
@@ -2189,11 +2192,13 @@ public class EventService : IEventService
         var ghostUser = await _context.Users.FirstOrDefaultAsync(u => u.Id == ghostUserId);
         if (ghostUser == null)
         {
+            _logger.LogWarning("Ghost player update failed: player {GhostUserId} not found", ghostUserId);
             throw new InvalidOperationException("Player not found");
         }
 
         if (!ghostUser.IsGhostPlayer)
         {
+            _logger.LogWarning("Ghost player update rejected for event {EventId}: user {GhostUserId} is not a guest player", eventId, ghostUserId);
             throw new InvalidOperationException("Only guest players can be edited. This player has a real account.");
         }
 
@@ -2204,6 +2209,7 @@ public class EventService : IEventService
 
         if (registration == null)
         {
+            _logger.LogWarning("Ghost player update rejected for event {EventId}: guest {GhostUserId} has no active registration", eventId, ghostUserId);
             throw new InvalidOperationException("This guest player is not registered for this event");
         }
 
@@ -2216,6 +2222,7 @@ public class EventService : IEventService
             var skaterCount = evt.Registrations.Count(r => r.Status == "Registered" && r.RegisteredPosition != "Goalie");
             if (skaterCount >= evt.MaxPlayers)
             {
+                _logger.LogWarning("Ghost player update rejected for event {EventId}: roster full, cannot switch guest {GhostUserId} from Goalie to Skater", eventId, ghostUserId);
                 throw new InvalidOperationException("The roster is full for skaters. Free up a skater spot before switching this guest from Goalie to Skater.");
             }
         }

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -121,21 +121,38 @@ public class EventService : IEventService
         };
 
         _context.Events.Add(evt);
-        await _context.SaveChangesAsync();
 
-        // Load organization for MapToDto if event belongs to one
         if (evt.OrganizationId.HasValue)
         {
-            evt.Organization = await _context.Organizations.FindAsync(evt.OrganizationId.Value);
-
-            // Auto-add the org's regulars before subscribers are notified,
-            // so they're placed before anyone else can register
-            if (request.ApplyAutoRoster)
+            // Create the event and place the org's auto-roster regulars atomically:
+            // a failure mid-placement must not leave a partially-rostered event committed.
+            // Serializable matches the cancellation/promotion paths elsewhere in this service.
+            await using var transaction = await _context.Database
+                .BeginTransactionAsync(IsolationLevel.Serializable);
+            try
             {
-                await ApplyAutoRosterAsync(evt);
+                await _context.SaveChangesAsync();
+
+                // Load organization for MapToDto and auto-roster placement
+                evt.Organization = await _context.Organizations.FindAsync(evt.OrganizationId.Value);
+
+                // Auto-add the org's regulars before subscribers are notified,
+                // so they're placed before anyone else can register
+                if (request.ApplyAutoRoster)
+                {
+                    await ApplyAutoRosterAsync(evt);
+                }
+
+                await transaction.CommitAsync();
+            }
+            catch
+            {
+                await transaction.RollbackAsync();
+                throw;
             }
 
-            // Notify organization subscribers about the new game
+            // Notify organization subscribers AFTER commit so a rollback can't send a
+            // "New Game" blast for an event that was never persisted
             var orgName = evt.Organization?.Name ?? "An organization";
             var venueText = !string.IsNullOrWhiteSpace(evt.Venue) ? $" - {evt.Venue}" : "";
             // Convert UTC to Central Time for display
@@ -148,6 +165,10 @@ public class EventService : IEventService
                 type: "new_event",
                 eventId: evt.Id
             );
+        }
+        else
+        {
+            await _context.SaveChangesAsync();
         }
 
         return await MapToDto(evt, creatorId);
@@ -2018,18 +2039,14 @@ public class EventService : IEventService
     /// </summary>
     private static string NormalizePosition(string? position)
     {
+        // Organizer adds treat a missing position as Skater; the shared normalizer
+        // validates and canonicalizes anything else.
         if (string.IsNullOrEmpty(position))
         {
             return "Skater";
         }
 
-        var normalized = position.ToLowerInvariant();
-        if (normalized != "goalie" && normalized != "skater")
-        {
-            throw new InvalidOperationException("Invalid position. Must be 'Goalie' or 'Skater'");
-        }
-
-        return normalized == "goalie" ? "Goalie" : "Skater";
+        return PositionNormalizer.Normalize(position);
     }
 
     /// <summary>

--- a/apps/api/BHMHockey.Api/Services/OrganizationAutoRosterService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationAutoRosterService.cs
@@ -38,7 +38,7 @@ public class OrganizationAutoRosterService : IOrganizationAutoRosterService
     {
         await EnsureAdminAsync(organizationId, requesterId);
 
-        var normalizedPosition = NormalizePosition(position);
+        var normalizedPosition = PositionNormalizer.Normalize(position);
 
         var isSubscriber = await _context.OrganizationSubscriptions
             .AnyAsync(s => s.OrganizationId == organizationId && s.UserId == userId);
@@ -132,17 +132,6 @@ public class OrganizationAutoRosterService : IOrganizationAutoRosterService
             _logger.LogWarning("Auto-roster access denied: user {RequesterId} is not an admin of organization {OrganizationId}", requesterId, organizationId);
             throw new UnauthorizedAccessException("You don't have permission to manage this organization's auto-roster");
         }
-    }
-
-    private static string NormalizePosition(string? position)
-    {
-        var normalized = position?.ToLowerInvariant();
-        if (normalized != "goalie" && normalized != "skater")
-        {
-            throw new InvalidOperationException("Invalid position. Must be 'Goalie' or 'Skater'");
-        }
-
-        return normalized == "goalie" ? "Goalie" : "Skater";
     }
 
     private static AutoRosterMemberDto MapToDto(OrganizationAutoRosterMember member)

--- a/apps/api/BHMHockey.Api/Services/OrganizationService.cs
+++ b/apps/api/BHMHockey.Api/Services/OrganizationService.cs
@@ -11,18 +11,21 @@ public class OrganizationService : IOrganizationService
     private readonly IOrganizationAdminService _adminService;
     private readonly IOrganizationWaiverService _waiverService;
     private readonly IEventService _eventService;
+    private readonly ILogger<OrganizationService> _logger;
     private static readonly HashSet<string> ValidSkillLevels = new() { "Gold", "Silver", "Bronze", "D-League" };
 
     public OrganizationService(
         AppDbContext context,
         IOrganizationAdminService adminService,
         IOrganizationWaiverService waiverService,
-        IEventService eventService)
+        IEventService eventService,
+        ILogger<OrganizationService> logger)
     {
         _context = context;
         _adminService = adminService;
         _waiverService = waiverService;
         _eventService = eventService;
+        _logger = logger;
     }
 
     private void ValidateSkillLevels(List<string>? skillLevels)
@@ -296,6 +299,11 @@ public class OrganizationService : IOrganizationService
         }
 
         await UnsubscribeAsync(organizationId, userId);
+
+        _logger.LogInformation(
+            "User {UserId} left organization {OrganizationId}; cancelled {Count} upcoming registration(s)",
+            userId, organizationId, upcomingEventIds.Count);
+
         return true;
     }
 

--- a/apps/api/BHMHockey.Api/Services/PositionNormalizer.cs
+++ b/apps/api/BHMHockey.Api/Services/PositionNormalizer.cs
@@ -1,0 +1,20 @@
+namespace BHMHockey.Api.Services;
+
+/// <summary>
+/// Canonicalizes a roster position to "Goalie" or "Skater", rejecting anything else.
+/// Callers decide how to treat a missing position: organizer adds default to Skater,
+/// while auto-roster requires an explicit choice (a null/blank position is invalid here).
+/// </summary>
+public static class PositionNormalizer
+{
+    public static string Normalize(string? position)
+    {
+        var normalized = position?.ToLowerInvariant();
+        if (normalized != "goalie" && normalized != "skater")
+        {
+            throw new InvalidOperationException("Invalid position. Must be 'Goalie' or 'Skater'");
+        }
+
+        return normalized == "goalie" ? "Goalie" : "Skater";
+    }
+}

--- a/apps/mobile/app/organizations/[id]/auto-roster.tsx
+++ b/apps/mobile/app/organizations/[id]/auto-roster.tsx
@@ -425,7 +425,7 @@ const styles = StyleSheet.create({
   },
   modalOverlay: {
     flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.7)',
+    backgroundColor: colors.overlay,
     justifyContent: 'flex-end',
   },
   modalContent: {

--- a/apps/mobile/components/event-detail/AddPlayerModal.tsx
+++ b/apps/mobile/components/event-detail/AddPlayerModal.tsx
@@ -56,7 +56,10 @@ export function AddPlayerModal({
   const [guestSkillLevel, setGuestSkillLevel] = useState<SkillLevel | null>(null);
   const [isCreatingGuest, setIsCreatingGuest] = useState(false);
 
-  const { searchUsersForEvent, addUserToEvent, createGhostPlayer, updateGhostPlayer } = useEventStore();
+  const searchUsersForEvent = useEventStore(state => state.searchUsersForEvent);
+  const addUserToEvent = useEventStore(state => state.addUserToEvent);
+  const createGhostPlayer = useEventStore(state => state.createGhostPlayer);
+  const updateGhostPlayer = useEventStore(state => state.updateGhostPlayer);
 
   const isEditMode = !!editingRegistration;
 

--- a/apps/mobile/components/event-detail/DraftModeRoster.tsx
+++ b/apps/mobile/components/event-detail/DraftModeRoster.tsx
@@ -229,7 +229,7 @@ const styles = StyleSheet.create({
   waitlistPositionBadge: {
     width: 32,
     height: 32,
-    borderRadius: 16,
+    borderRadius: radius.round,
     backgroundColor: colors.status.warningSubtle,
     justifyContent: 'center',
     alignItems: 'center',
@@ -251,6 +251,6 @@ const styles = StyleSheet.create({
   waitlistUserMeta: {
     fontSize: 13,
     color: colors.text.muted,
-    marginTop: 2,
+    marginTop: spacing.xxs,
   },
 });

--- a/apps/mobile/stores/eventStore.ts
+++ b/apps/mobile/stores/eventStore.ts
@@ -3,7 +3,7 @@ import { eventService } from '@bhmhockey/api-client';
 import type { EventDto, CreateEventRequest, Position, TeamAssignment, RegistrationResultDto, PaymentStatus, WaitlistOrderItem, PaymentUpdateResultDto, PublishResultDto, UserSearchResultDto, SkillLevel } from '@bhmhockey/shared';
 
 /** Extract message from ApiError objects or Error instances */
-function getErrorMessage(error: unknown, fallback: string): string {
+export function getErrorMessage(error: unknown, fallback: string): string {
   if (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string') {
     return (error as any).message || fallback;
   }

--- a/apps/mobile/stores/organizationStore.ts
+++ b/apps/mobile/stores/organizationStore.ts
@@ -1,15 +1,7 @@
 import { create } from 'zustand';
 import { organizationService } from '@bhmhockey/api-client';
 import type { Organization, OrganizationSubscription, CreateOrganizationRequest, OrganizationMember, AutoRosterMember, Position, OrganizationWaiver } from '@bhmhockey/shared';
-import { useEventStore } from './eventStore';
-
-/** Extract message from ApiError objects or Error instances */
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string') {
-    return (error as any).message || fallback;
-  }
-  return fallback;
-}
+import { useEventStore, getErrorMessage } from './eventStore';
 
 interface OrganizationState {
   organizations: Organization[];

--- a/apps/mobile/stores/waiverStore.ts
+++ b/apps/mobile/stores/waiverStore.ts
@@ -2,15 +2,7 @@ import { create } from 'zustand';
 import { organizationService } from '@bhmhockey/api-client';
 import type { PendingWaiver, WaiverSignatureDetails } from '@bhmhockey/shared';
 import { useOrganizationStore } from './organizationStore';
-import { useEventStore } from './eventStore';
-
-/** Extract message from ApiError objects or Error instances */
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string') {
-    return (error as any).message || fallback;
-  }
-  return fallback;
-}
+import { useEventStore, getErrorMessage } from './eventStore';
 
 interface WaiverState {
   // Orgs where the user holds an upcoming registration but hasn't accepted the

--- a/apps/mobile/theme/index.ts
+++ b/apps/mobile/theme/index.ts
@@ -67,9 +67,13 @@ export const colors = {
     Bronze: '#4D3D2E',    // Very muted bronze
     'D-League': '#463D54', // Very muted purple
   },
+
+  // Modal / backdrop scrim
+  overlay: 'rgba(0, 0, 0, 0.7)',
 } as const;
 
 export const spacing = {
+  xxs: 2,
   xs: 4,
   sm: 8,
   md: 16,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -125,7 +125,7 @@ export interface SetOrganizationWaiverResponse {
 
 // Signature fields captured on the acceptance form and recorded once on the
 // acceptance row (immutable audit data). Dates are calendar dates sent as
-// YYYY-MM-DD. participantName/participantDate are always required; the
+// YYYY-MM-DD. participantName is always required; the
 // Parent/Guardian section is all-or-nothing (required if the participant is
 // under 19): either every minor field is present or all are omitted.
 // Signature dates are stamped server-side at acceptance time - the client


### PR DESCRIPTION
## Summary

Addresses findings from the two-axis code review of PRs #19–#26 (the batch of commits merged to `main`). Two commits:

**1. Standards axis — documented-convention fixes**
- **Failure-path logging** (`apps/api/CLAUDE.md` §Logging: "Do NOT skip logging on failure paths") — added `LogWarning` on previously-silent error paths:
  - `EventService.UpdateGhostPlayerAsync` — before all 7 throws
  - `EventsController.UpdateGhostPlayer` — the `Forbid()` path
  - `UsersController.GetMyPendingWaivers` — the `Unauthorized` path (injected `ILogger`)
  - `OrganizationsController.Leave` — wrapped in try/catch → `400` + log (was an unlogged 500)
  - `OrganizationService.LeaveAsync` — injected `ILogger`, `LogInformation` on the registration-cancelling side effect
- **Zustand selectors** (`apps/mobile/CLAUDE.md` §State Management) — `AddPlayerModal` reads each store action via an individual selector.
- **Theme tokens** (`apps/mobile/CLAUDE.md` §Theme) — added `colors.overlay` and `spacing.xxs`; applied them + `radius.round` in `auto-roster.tsx` and `DraftModeRoster.tsx` (no visual change).

**2. Spec + quality fixes**
- **Auto-roster atomicity** (PR20 claimed placement is "atomic") — `EventService.CreateAsync` now wraps the event insert and every auto-roster placement in one `Serializable` transaction, committing before the "New Game" notification. A mid-placement failure now rolls the whole event back instead of leaving a partially-rostered event committed; the notification moved after commit so a rollback can't blast a false "New Game". Matches the cancellation/promotion transaction pattern already in the service.
- **De-dup `getErrorMessage`** — now exported from `eventStore.ts` and imported by `waiverStore`/`organizationStore` (was copy-pasted into all three).
- **De-dup position validation** — extracted `PositionNormalizer.Normalize`; each caller keeps its distinct missing-position behavior (organizer adds default to Skater; auto-roster requires an explicit position).
- **Stale comments** — `AcceptWaiverRequest`/`WaiverSignatureDetails` referenced a non-existent `ParticipantDate` field; corrected.

## Scope notes
- The `rgba(0,0,0,0.7)` scrim is an app-wide value in 20+ files; this PR adds the `colors.overlay` token and migrates only the reviewed file. Migrating the rest is a separate cleanup.
- Not addressed here (flagged but out of scope): larger `EventService.cs` divergent-change split; PR26's "required if under 19" is not enforceable without a profile DOB (a product decision).

## Testing
- **API:** 1105/1105
- **Mobile:** 150/150, type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYCkVPMii2urJEB5T2nLE