### PR TITLE
Fix EAS owner to match the production project account

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -59,7 +59,7 @@
         "projectId": "f6225f7a-0181-4b8c-b44a-cea3e0017cfa"
       }
     },
-    "owner": "adilp",
+    "owner": "a3quum",
     "runtimeVersion": "1.0.0",
     "updates": {
       "url": "https://u.expo.dev/f6225f7a-0181-4b8c-b44a-cea3e0017cfa",


### PR DESCRIPTION
## Summary

`app.json` declared `"owner": "adilp"`, but the EAS project that installed production builds check for updates (`f6225f7a-0181-4b8c-b44a-cea3e0017cfa`) is owned by the **a3quum** account. The mismatch made `eas update` refuse to publish. This sets `owner` to `a3quum` so OTA updates reach existing installs.

## Context

Surfaced while publishing the #27 OTA. The owner field had been `adilp` since `app.json` was first added, so this is a longstanding inconsistency that only blocked publishing now.

The production OTA has **already been published** to the a3quum project (runtime `1.0.0`, both platforms) using this change locally; this PR just lands the one-line config fix on `main` so the repo matches what's published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QYCkVPMii2urJEB5T2nLE