### PR TITLE
Show the position a user signed up for on the event info tab

### DIFF
--- a/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
+++ b/apps/api/BHMHockey.Api.Tests/Services/EventServiceTests.cs
@@ -2682,6 +2682,52 @@ public class EventServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetByIdAsync_UnpublishedEvent_OwnPositionStillVisible()
+    {
+        // Own signed-up position is not draft-gated (unlike team assignment)
+        var creator = await CreateTestUser("creator@example.com");
+        var player = await CreateTestUser("player@example.com");
+        var evt = await CreateTestEvent(creator.Id, isRosterPublished: false);
+        await _sut.RegisterAsync(evt.Id, player.Id);
+
+        var result = await _sut.GetByIdAsync(evt.Id, player.Id);
+
+        result!.IsRosterPublished.Should().BeFalse();
+        result.MyTeamAssignment.Should().BeNull();          // Team hidden during draft
+        result.MyRegisteredPosition.Should().Be("Skater");  // Position still visible
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_RegisteredAsGoalie_ExposesOwnPosition()
+    {
+        // Arrange - dual-position players need to see which role they signed up as
+        var creator = await CreateTestUser("creator@example.com");
+        var goalie = await CreateTestUser(
+            "goalie@example.com",
+            positions: new Dictionary<string, string> { { "goalie", "Gold" }, { "skater", "Silver" } });
+        var evt = await CreateTestEvent(creator.Id);
+        await _sut.RegisterAsync(evt.Id, goalie.Id, "Goalie");
+
+        // Act
+        var result = await _sut.GetByIdAsync(evt.Id, goalie.Id);
+
+        // Assert
+        result!.MyRegisteredPosition.Should().Be("Goalie");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_NotRegistered_OwnPositionIsNull()
+    {
+        var creator = await CreateTestUser("creator@example.com");
+        var viewer = await CreateTestUser("viewer@example.com");
+        var evt = await CreateTestEvent(creator.Id);
+
+        var result = await _sut.GetByIdAsync(evt.Id, viewer.Id);
+
+        result!.MyRegisteredPosition.Should().BeNull();
+    }
+
+    [Fact]
     public async Task GetByIdAsync_UnpublishedEvent_Organizer_SeesPlacementDetails()
     {
         // Arrange

--- a/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
+++ b/apps/api/BHMHockey.Api/Models/DTOs/EventDTOs.cs
@@ -45,7 +45,10 @@ public record EventDto(
     bool? MyWaitlistPaymentEligible = null,  // null when not applicable (not waitlisted or free event)
     // Waiver gate for the current user: org event + active waiver + not accepted
     // (same rule for everyone with a real account, including managers)
-    bool RequiresWaiverAcceptance = false
+    bool RequiresWaiverAcceptance = false,
+    // Position the current user registered/waitlisted with ("Goalie" or "Skater";
+    // null when not signed up) - matters for players who play both
+    string? MyRegisteredPosition = null
 );
 
 public record CreateEventRequest(

--- a/apps/api/BHMHockey.Api/Services/EventService.cs
+++ b/apps/api/BHMHockey.Api/Services/EventService.cs
@@ -1013,6 +1013,7 @@ public class EventService : IEventService
         // Include both registered AND waitlisted users for payment status
         string? myPaymentStatus = null;
         string? myTeamAssignment = null;
+        string? myRegisteredPosition = null;
         if (currentUserId.HasValue)
         {
             var myRegistration = evt.Registrations?.FirstOrDefault(r => r.UserId == currentUserId.Value && (r.Status == "Registered" || r.Status == "Waitlisted"))
@@ -1021,6 +1022,10 @@ public class EventService : IEventService
             {
                 // Payment status always visible (players need to know their payment state during draft)
                 myPaymentStatus = evt.Cost > 0 ? myRegistration.PaymentStatus : null;
+
+                // Own position always visible - dual-position players need to know
+                // which role they signed up for, published or not
+                myRegisteredPosition = myRegistration.RegisteredPosition;
 
                 // Team assignment only visible if roster is published OR user can manage
                 if (evt.IsRosterPublished || canManage)
@@ -1129,7 +1134,8 @@ public class EventService : IEventService
             groupMeLinkSource,   // "event" | "organization" | null
             evt.ShowWaitlistBeforePublish,  // Waitlist visibility (pre-publish)
             myWaitlistPaymentEligible,      // Pay-eligibility for current user's waitlisted spot
-            requiresWaiverAcceptance        // Waiver gate for the current user
+            requiresWaiverAcceptance,       // Waiver gate for the current user
+            myRegisteredPosition            // Goalie/Skater the user signed up as
         );
     }
 

--- a/apps/mobile/components/event-detail/EventInfoTab.tsx
+++ b/apps/mobile/components/event-detail/EventInfoTab.tsx
@@ -128,6 +128,10 @@ export function EventInfoTab({
                 {event.myWaitlistPosition ? `#${event.myWaitlistPosition} Waitlist` : 'Waitlist'}
               </Badge>
             )}
+            {/* Which position they signed up as - matters for dual-position players */}
+            {(event.isRegistered || event.amIWaitlisted) && event.myRegisteredPosition && (
+              <Badge variant="teal">{event.myRegisteredPosition}</Badge>
+            )}
             {/* Payment status badge for registered/waitlisted users on paid events */}
             {(event.isRegistered || event.amIWaitlisted) && event.cost > 0 && (
               <Badge variant={paymentBadge.variant}>{paymentBadge.text}</Badge>

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -310,6 +310,9 @@ export interface EventDto {
   // Waiver gate for the current user: org event + active waiver + not accepted
   // (same rule for everyone with a real account, including managers)
   requiresWaiverAcceptance: boolean;
+  // Position the current user signed up with ("Goalie"/"Skater"; null when not
+  // signed up) - matters for players who play both
+  myRegisteredPosition?: Position | null;
   // Slot position labels (organizer feature)
   slotPositionLabels?: Record<number, string>; // Maps slot index to position label (e.g., {1: "C", 2: "LW"})
   // GroupMe chat link, resolved server-side at read time: event override wins, else org's link


### PR DESCRIPTION
## Summary

Players who play both goalie and skater had no way to see which position they registered with. `EventDto` now exposes `MyRegisteredPosition` for the current user, and the info tab's status badge row shows it as a teal badge beside Registered/Waitlist.

## Notes

- Placed in the status badge row (not the payment section) so it appears on free events too.
- Not draft-gated, unlike team assignment — knowing which role you committed to shouldn't depend on the organizer publishing the roster.
- Null when the viewer isn't registered or waitlisted. No new endpoint, no migration, no notification changes.

## Testing

- API: 1105 → 1108 (goalie signup exposure, null when not registered, still visible pre-publish)
- Frontend: shared 41, api-client 40, mobile 150; mobile type-check clean
- Verified live against the local API: a registered user returns `myRegisteredPosition: "Skater"` alongside team and publish state

🤖 Generated with [Claude Code](https://claude.com/claude-code)